### PR TITLE
Detect stale content

### DIFF
--- a/Kentico.Kontent.Delivery.Rx/DeliveryObservableProxy.cs
+++ b/Kentico.Kontent.Delivery.Rx/DeliveryObservableProxy.cs
@@ -176,7 +176,7 @@ namespace Kentico.Kontent.Delivery.Rx
         /// <returns>The <see cref="IObservable{ContentType}"/> that represents the content type with the specified codename.</returns>
         public IObservable<ContentType> GetTypeObservable(string codename)
         {
-            return GetObservableOfOne(() => DeliveryClient?.GetTypeAsync(codename)?.Result);
+            return GetObservableOfOne(() => DeliveryClient?.GetTypeAsync(codename)?.Result.Type);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Kentico.Kontent.Delivery.Rx
         /// <returns>An <see cref="IObservable{ContentElement}"/> that represents the content element with the specified codename, that is a part of a content type with the specified codename.</returns>
         public IObservable<ContentElement> GetElementObservable(string contentTypeCodename, string contentElementCodename)
         {
-            return GetObservableOfOne(() => DeliveryClient?.GetContentElementAsync(contentTypeCodename, contentElementCodename)?.Result);
+            return GetObservableOfOne(() => DeliveryClient?.GetContentElementAsync(contentTypeCodename, contentElementCodename)?.Result.Element);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace Kentico.Kontent.Delivery.Rx
         /// <returns>The <see cref="IObservable{TaxonomyGroup}"/> that represents the taxonomy group with the specified codename.</returns>
         public IObservable<TaxonomyGroup> GetTaxonomyObservable(string codename)
         {
-            return GetObservableOfOne(() => DeliveryClient?.GetTaxonomyAsync(codename)?.Result);
+            return GetObservableOfOne(() => DeliveryClient?.GetTaxonomyAsync(codename)?.Result.Taxonomy);
         }
 
         /// <summary>

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -183,8 +183,8 @@ namespace Kentico.Kontent.Delivery.Tests
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
 
-            var articleType = await client.GetTypeAsync("article");
-            var coffeeType = await client.GetTypeAsync("coffee");
+            var articleType = (await client.GetTypeAsync("article")).Type;
+            var coffeeType = (await client.GetTypeAsync("coffee")).Type;
 
             var taxonomyElement = articleType.Elements["personas"];
             var processingTaxonomyElement = coffeeType.Elements["processing"];
@@ -251,9 +251,9 @@ namespace Kentico.Kontent.Delivery.Tests
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
 
-            var element = await client.GetContentElementAsync(Article.Codename, Article.TitleCodename);
-            var personasTaxonomyElement = await client.GetContentElementAsync(Article.Codename, Article.PersonasCodename);
-            var processingTaxonomyElement = await client.GetContentElementAsync(Coffee.Codename, Coffee.ProcessingCodename);
+            var element = (await client.GetContentElementAsync(Article.Codename, Article.TitleCodename)).Element;
+            var personasTaxonomyElement = (await client.GetContentElementAsync(Article.Codename, Article.PersonasCodename)).Element;
+            var processingTaxonomyElement = (await client.GetContentElementAsync(Coffee.Codename, Coffee.ProcessingCodename)).Element;
 
             Assert.Equal(Article.TitleCodename, element.Codename);
             Assert.Equal(Article.PersonasCodename, personasTaxonomyElement.TaxonomyGroup);
@@ -284,7 +284,7 @@ namespace Kentico.Kontent.Delivery.Tests
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
 
-            var taxonomy = await client.GetTaxonomyAsync("personas");
+            var taxonomy = (await client.GetTaxonomyAsync("personas")).Taxonomy;
             var personasTerms = taxonomy.Terms.ToList();
             var coffeeExpertTerms = personasTerms[0].Terms.ToList();
 
@@ -886,6 +886,348 @@ namespace Kentico.Kontent.Delivery.Tests
             await client.GetItemsAsync();
 
             _mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async void GetItemAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemAsync("test");
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetItemAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemAsync("test");
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetItemsAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemsAsync();
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetItemsAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemsAsync();
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetCustomItemAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemAsync<Homepage>("test");
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetCustomItemAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemAsync<Homepage>("test");
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetCustomItemsAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemsAsync<Homepage>();
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetCustomItemsAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/items")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetItemsAsync<Homepage>();
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTypeAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTypeAsync("test");
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTypeAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTypeAsync("test");
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTypesAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTypesAsync();
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTypesAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTypesAsync();
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTaxonomyAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/taxonomies/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTaxonomyAsync("test");
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTaxonomyAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/taxonomies/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTaxonomyAsync("test");
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTaxonomiesAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/taxonomies")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTaxonomiesAsync();
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetTaxonomiesAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/taxonomies")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetTaxonomiesAsync();
+
+            Assert.False(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetElementAsync_ApiReturnsStaleContent_ResponseIndicatesStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "1")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types/test/elements/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetContentElementAsync("test", "test");
+
+            Assert.True(response.HasStaleContent);
+        }
+
+        [Fact]
+        public async void GetElementAsync_ApiDoesNotReturnStaleContent_ResponseDoesNotIndicateStaleContent()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>("X-Stale-Content", "0")
+            };
+
+            _mockHttp
+                .When($"{_baseUrl}/types/test/elements/test")
+                .Respond(headers, "application/json", "{ }");
+
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp);
+
+            var response = await client.GetContentElementAsync("test", "test");
+
+            Assert.False(response.HasStaleContent);
         }
 
         [Fact]

--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -83,7 +83,7 @@ namespace Kentico.Kontent.Delivery
 
             var endpointUrl = UrlBuilder.GetItemUrl(codename, parameters);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Kentico.Kontent.Delivery
         {
             var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetItemUrl(codename, parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryItemResponse(response, ModelProvider, ContentLinkUrlResolver, endpointUrl);
+            return new DeliveryItemResponse(response, ModelProvider, ContentLinkUrlResolver);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetItemUrl(codename, parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryItemResponse<T>(response, ModelProvider, endpointUrl);
+            return new DeliveryItemResponse<T>(response, ModelProvider);
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryItemListingResponse(response, ModelProvider, ContentLinkUrlResolver, endpointUrl);
+            return new DeliveryItemListingResponse(response, ModelProvider, ContentLinkUrlResolver);
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetItemsUrl(enhancedParameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryItemListingResponse<T>(response, ModelProvider, endpointUrl);
+            return new DeliveryItemListingResponse<T>(response, ModelProvider);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Kentico.Kontent.Delivery
 
             var endpointUrl = UrlBuilder.GetTypeUrl(codename);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
@@ -245,15 +245,15 @@ namespace Kentico.Kontent.Delivery
         {
             var endpointUrl = UrlBuilder.GetTypesUrl(parameters);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
-        /// Returns a content type.
+        /// Gets a content type by its codename.
         /// </summary>
         /// <param name="codename">The codename of a content type.</param>
-        /// <returns>The content type with the specified codename.</returns>
-        public async Task<ContentType> GetTypeAsync(string codename)
+        /// <returns>The <see cref="DeliveryTypeResponse"/> instance that contains the content type with the specified codename.</returns>
+        public async Task<DeliveryTypeResponse> GetTypeAsync(string codename)
         {
             if (codename == null)
             {
@@ -268,39 +268,39 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetTypeUrl(codename);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new ContentType(response);
+            return new DeliveryTypeResponse(response);
         }
 
         /// <summary>
-        /// Returns content types.
+        /// Returns content types that match the optional filtering parameters.
         /// </summary>
         /// <param name="parameters">An array that contains zero or more query parameters, for example, for paging.</param>
-        /// <returns>The <see cref="DeliveryTypeListingResponse"/> instance that represents the content types. If no query parameters are specified, all content types are returned.</returns>
+        /// <returns>The <see cref="DeliveryTypeListingResponse"/> instance that contains the content types. If no query parameters are specified, all content types are returned.</returns>
         public async Task<DeliveryTypeListingResponse> GetTypesAsync(params IQueryParameter[] parameters)
         {
             return await GetTypesAsync((IEnumerable<IQueryParameter>)parameters);
         }
 
         /// <summary>
-        /// Returns content types.
+        /// Returns content types that match the optional filtering parameters.
         /// </summary>
         /// <param name="parameters">A collection of query parameters, for example, for paging.</param>
-        /// <returns>The <see cref="DeliveryTypeListingResponse"/> instance that represents the content types. If no query parameters are specified, all content types are returned.</returns>
+        /// <returns>The <see cref="DeliveryTypeListingResponse"/> instance that contains the content types. If no query parameters are specified, all content types are returned.</returns>
         public async Task<DeliveryTypeListingResponse> GetTypesAsync(IEnumerable<IQueryParameter> parameters)
         {
             var endpointUrl = UrlBuilder.GetTypesUrl(parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryTypeListingResponse(response, endpointUrl);
+            return new DeliveryTypeListingResponse(response);
         }
 
         /// <summary>
-        /// Returns a content element.
+        /// Returns a content type element.
         /// </summary>
         /// <param name="contentTypeCodename">The codename of the content type.</param>
-        /// <param name="contentElementCodename">The codename of the content element.</param>
-        /// <returns>A content element with the specified codename that is a part of a content type with the specified codename.</returns>
-        public async Task<ContentElement> GetContentElementAsync(string contentTypeCodename, string contentElementCodename)
+        /// <param name="contentElementCodename">The codename of the content type element.</param>
+        /// <returns>The <see cref="DeliveryElementResponse"/> instance that contains the specified content type element.</returns>
+        public async Task<DeliveryElementResponse> GetContentElementAsync(string contentTypeCodename, string contentElementCodename)
         {
             if (contentTypeCodename == null)
             {
@@ -325,11 +325,8 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetContentElementUrl(contentTypeCodename, contentElementCodename);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            var elementCodename = response["codename"].ToString();
-
-            return new ContentElement(response, elementCodename);
+            return new DeliveryElementResponse(response);
         }
-
 
         /// <summary>
         /// Returns a taxonomy group as JSON data.
@@ -350,7 +347,7 @@ namespace Kentico.Kontent.Delivery
 
             var endpointUrl = UrlBuilder.GetTaxonomyUrl(codename);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
@@ -362,15 +359,15 @@ namespace Kentico.Kontent.Delivery
         {
             var endpointUrl = UrlBuilder.GetTaxonomiesUrl(parameters);
 
-            return await GetDeliverResponseAsync(endpointUrl);
+            return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
 
         /// <summary>
         /// Returns a taxonomy group.
         /// </summary>
         /// <param name="codename">The codename of a taxonomy group.</param>
-        /// <returns>The taxonomy group with the specified codename.</returns>
-        public async Task<TaxonomyGroup> GetTaxonomyAsync(string codename)
+        /// <returns>The <see cref="DeliveryTaxonomyResponse"/> instance that contains the taxonomy group with the specified codename.</returns>
+        public async Task<DeliveryTaxonomyResponse> GetTaxonomyAsync(string codename)
         {
             if (codename == null)
             {
@@ -385,7 +382,7 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetTaxonomyUrl(codename);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new TaxonomyGroup(response);
+            return new DeliveryTaxonomyResponse(response);
         }
 
         /// <summary>
@@ -408,10 +405,10 @@ namespace Kentico.Kontent.Delivery
             var endpointUrl = UrlBuilder.GetTaxonomiesUrl(parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
-            return new DeliveryTaxonomyListingResponse(response, endpointUrl);
+            return new DeliveryTaxonomyListingResponse(response);
         }
 
-        private async Task<JObject> GetDeliverResponseAsync(string endpointUrl)
+        private async Task<ApiResponse> GetDeliverResponseAsync(string endpointUrl)
         {
             if (DeliveryOptions.UsePreviewApi && DeliveryOptions.UseSecuredProductionApi)
             {
@@ -468,13 +465,14 @@ namespace Kentico.Kontent.Delivery
             return DeliveryOptions.UsePreviewApi && !string.IsNullOrEmpty(DeliveryOptions.PreviewApiKey);
         }
 
-        private async Task<JObject> GetResponseContent(HttpResponseMessage httpResponseMessage)
+        private async Task<ApiResponse> GetResponseContent(HttpResponseMessage httpResponseMessage)
         {
             if (httpResponseMessage?.StatusCode == HttpStatusCode.OK)
             {
-                var content = await httpResponseMessage.Content?.ReadAsStringAsync();
+                var content = JObject.Parse(await httpResponseMessage.Content?.ReadAsStringAsync());
+                var hasStaleContent = HasStaleContent(httpResponseMessage);
 
-                return JObject.Parse(content);
+                return new ApiResponse(content, hasStaleContent: hasStaleContent, requestUrl: httpResponseMessage.RequestMessage.RequestUri.AbsoluteUri);
             }
 
             string faultContent = null;
@@ -486,6 +484,11 @@ namespace Kentico.Kontent.Delivery
             }
 
             throw new DeliveryException(httpResponseMessage, "Either the retry policy was disabled or all retry attempts were depleted.\nFault content:\n" + faultContent);
+        }
+
+        private bool HasStaleContent(HttpResponseMessage httpResponseMessage)
+        {
+            return httpResponseMessage.Headers.TryGetValues("X-Stale-Content", out var values) && values.Contains("1", StringComparer.Ordinal);
         }
 
         internal IEnumerable<IQueryParameter> ExtractParameters<T>(IEnumerable<IQueryParameter> parameters = null)

--- a/Kentico.Kontent.Delivery/IDeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/IDeliveryClient.cs
@@ -106,8 +106,8 @@ namespace Kentico.Kontent.Delivery
         /// Returns a content type.
         /// </summary>
         /// <param name="codename">The codename of a content type.</param>
-        /// <returns>The content type with the specified codename.</returns>
-        Task<ContentType> GetTypeAsync(string codename);
+        /// <returns>The <see cref="DeliveryTypeResponse"/> instance that contains the content type with the specified codename.</returns>
+        Task<DeliveryTypeResponse> GetTypeAsync(string codename);
 
         /// <summary>
         /// Returns content types.
@@ -124,12 +124,12 @@ namespace Kentico.Kontent.Delivery
         Task<DeliveryTypeListingResponse> GetTypesAsync(IEnumerable<IQueryParameter> parameters);
 
         /// <summary>
-        /// Returns a content element.
+        /// Returns a content type element.
         /// </summary>
         /// <param name="contentTypeCodename">The codename of the content type.</param>
-        /// <param name="contentElementCodename">The codename of the content element.</param>
-        /// <returns>A content element with the specified codename that is a part of a content type with the specified codename.</returns>
-        Task<ContentElement> GetContentElementAsync(string contentTypeCodename, string contentElementCodename);
+        /// <param name="contentElementCodename">The codename of the content type element.</param>
+        /// <returns>The <see cref="DeliveryElementResponse"/> instance that contains the specified content type element.</returns>
+        Task<DeliveryElementResponse> GetContentElementAsync(string contentTypeCodename, string contentElementCodename);
 
         /// <summary>
         /// Returns a taxonomy group as JSON data.
@@ -149,8 +149,8 @@ namespace Kentico.Kontent.Delivery
         /// Returns a taxonomy group.
         /// </summary>
         /// <param name="codename">The codename of a taxonomy group.</param>
-        /// <returns>The taxonomy group with the specified codename.</returns>
-        Task<TaxonomyGroup> GetTaxonomyAsync(string codename);
+        /// <returns>The <see cref="DeliveryTaxonomyResponse"/> instance that contains the taxonomy group with the specified codename.</returns>
+        Task<DeliveryTaxonomyResponse> GetTaxonomyAsync(string codename);
 
         /// <summary>
         /// Returns taxonomy groups.

--- a/Kentico.Kontent.Delivery/Responses/AbstractResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/AbstractResponse.cs
@@ -1,27 +1,34 @@
 ﻿namespace Kentico.Kontent.Delivery
 {
     /// <summary>
-    /// Base class for response objects.
+    /// Represents a successful response from Kentico Kontent Delivery API.
     /// </summary>
     public abstract class AbstractResponse
     {
-        #region "Debugging properties"
+        /// <summary>
+        /// The successful JSON response from Kentico Kontent Delivery API.
+        /// </summary>
+        protected readonly ApiResponse _response;
 
         /// <summary>
-        /// The URL of the request sent to the Kentico Kontent endpoint by the <see cref="DeliveryClient"/>.
-        /// Useful for debugging.
+        /// Gets a value that determines whether content is stale.
+        /// Stale content indicates that there is a more recent version, but it will become available later.
+        /// Stale content should be cached only for a limited period of time.
         /// </summary>
-        public string ApiUrl { get; protected set; }
-
-        #endregion
+        public bool HasStaleContent => _response.HasStaleContent;
 
         /// <summary>
-        /// Default constructor.
+        /// Gets the URL used to retrieve this response for debugging purposes.
         /// </summary>
-        /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        protected AbstractResponse(string apiUrl)
+        public string ApiUrl => _response.RequestUrl;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbstractResponse"/> class.
+        /// </summary>
+        /// <param name="response">A successful JSON response from Kentico Kontent Delivery API.</param>
+        protected AbstractResponse(ApiResponse response)
         {
-            ApiUrl = apiUrl;
+            _response = response;
         }
     }
 }

--- a/Kentico.Kontent.Delivery/Responses/ApiResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/ApiResponse.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Represents a successful JSON response from Kentico Kontent Delivery API.
+    /// </summary>
+    public sealed class ApiResponse
+    {
+        /// <summary>
+        /// Gets JSON content.
+        /// </summary>
+        public JObject Content { get; }
+
+        /// <summary>
+        /// Gets a value that determines whether content is stale.
+        /// Stale content indicates that there is a more recent version, but it will become available later.
+        /// Stale content should be cached only for a limited period of time.
+        /// </summary>
+        public bool HasStaleContent { get; }
+
+        /// <summary>
+        /// Gets the URL used to retrieve this response for debugging purposes.
+        /// </summary>
+        public string RequestUrl { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse"/> class.
+        /// </summary>
+        /// <param name="content">JSON content.</param>
+        /// <param name="hasStaleContent">Specifies whether content is stale.</param>
+        /// <param name="requestUrl">The URL used to retrieve this response.</param>
+        internal ApiResponse(JObject content, bool hasStaleContent, string requestUrl)
+        {
+            Content = content;
+            HasStaleContent = hasStaleContent;
+            RequestUrl = requestUrl;
+        }
+    }
+}

--- a/Kentico.Kontent.Delivery/Responses/DeliveryElementResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryElementResponse.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Represents a response from Kentico Kontent Delivery API that contains a content type element.
+    /// </summary>
+    public sealed class DeliveryElementResponse : AbstractResponse
+    {
+        private readonly Lazy<ContentElement> _element;
+
+        /// <summary>
+        /// Gets the content type element.
+        /// </summary>
+        public ContentElement Element => _element.Value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeliveryElementResponse"/> class.
+        /// </summary>
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a content type element.</param>
+        internal DeliveryElementResponse(ApiResponse response) : base(response)
+        {
+            _element = new Lazy<ContentElement>(() => new ContentElement(_response.Content, _response.Content.Value<string>("codename")), LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        /// Implicitly converts the specified <paramref name="response"/> to a content type element.
+        /// </summary>
+        /// <param name="response">The response to convert.</param>
+        public static implicit operator ContentElement(DeliveryElementResponse response) => response.Element;
+    }
+}

--- a/Kentico.Kontent.Delivery/Responses/DeliveryItemListingResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryItemListingResponse.cs
@@ -1,6 +1,8 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using Newtonsoft.Json.Linq;
 
 namespace Kentico.Kontent.Delivery
 {
@@ -9,58 +11,49 @@ namespace Kentico.Kontent.Delivery
     /// </summary>
     public sealed class DeliveryItemListingResponse : AbstractResponse
     {
-        private readonly JToken _response;
         private readonly IModelProvider _modelProvider;
         private readonly IContentLinkUrlResolver _contentLinkUrlResolver;
-        private Pagination _pagination;
-        private IReadOnlyList<ContentItem> _items;
-        private dynamic _linkedItems;
+        private readonly Lazy<Pagination> _pagination;
+        private readonly Lazy<IReadOnlyList<ContentItem>> _items;
+        private readonly Lazy<JObject> _linkedItems;
 
         /// <summary>
         /// Gets paging information.
         /// </summary>
-        public Pagination Pagination
-        {
-            get { return _pagination ?? (_pagination = _response["pagination"].ToObject<Pagination>()); }
-        }
+        public Pagination Pagination => _pagination.Value;
 
         /// <summary>
-        /// Gets a list of content items.
+        /// Gets a read-only list of content items.
         /// </summary>
-        public IReadOnlyList<ContentItem> Items
-        {
-            get { return _items ?? (_items = ((JArray)_response["items"]).Select(source => new ContentItem(source, _response["modular_content"], _contentLinkUrlResolver, _modelProvider)).ToList().AsReadOnly()); }
-        }
+        public IReadOnlyList<ContentItem> Items => _items.Value;
 
         /// <summary>
         /// Gets the dynamic view of the JSON response where linked items and their properties can be retrieved by name, for example <c>LinkedItems.about_us.elements.description.value</c>.
         /// </summary>
-        public dynamic LinkedItems
-        {
-            get { return _linkedItems ?? (_linkedItems = JObject.Parse(_response["modular_content"].ToString())); }
-        }
+        public dynamic LinkedItems => _linkedItems.Value;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeliveryItemListingResponse"/> class with information from a response.
+        /// Initializes a new instance of the <see cref="DeliveryItemListingResponse"/> class.
         /// </summary>
-        /// <param name="response">A response from Kentico Kontent Delivery API that contains a list of content items.</param>
-        /// /// <param name="modelProvider">An instance of an object that can JSON responses into strongly typed CLR objects</param>
-        /// <param name="contentLinkUrlResolver">An instance of an object that can resolve links in rich text elements</param>
-        /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        internal DeliveryItemListingResponse(JToken response, IModelProvider modelProvider, IContentLinkUrlResolver contentLinkUrlResolver, string apiUrl) : base(apiUrl)
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a list of content items.</param>
+        /// <param name="modelProvider">The provider that can convert JSON responses into instances of .NET types.</param>
+        /// <param name="contentLinkUrlResolver">The resolver that can generate URLs for links in rich text elements.</param>
+        internal DeliveryItemListingResponse(ApiResponse response, IModelProvider modelProvider, IContentLinkUrlResolver contentLinkUrlResolver) : base(response)
         {
-            _response = response;
             _modelProvider = modelProvider;
             _contentLinkUrlResolver = contentLinkUrlResolver;
+            _pagination = new Lazy<Pagination>(() => _response.Content["pagination"].ToObject<Pagination>(), LazyThreadSafetyMode.PublicationOnly);
+            _items = new Lazy<IReadOnlyList<ContentItem>>(() => ((JArray)_response.Content["items"]).Select(source => new ContentItem(source, _response.Content["modular_content"], _contentLinkUrlResolver, _modelProvider)).ToList().AsReadOnly(), LazyThreadSafetyMode.PublicationOnly);
+            _linkedItems = new Lazy<JObject>(() => (JObject)_response.Content["modular_content"].DeepClone(), LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>
-        /// Casts DeliveryItemListingResponse to its generic version. Use this method only when the listed items are of the same type.
+        /// Casts this response to a generic one. To succeed all items must be of the same type.
         /// </summary>
-        /// <typeparam name="T">Target type.</typeparam>
+        /// <typeparam name="T">The object type that the items will be deserialized to.</typeparam>
         public DeliveryItemListingResponse<T> CastTo<T>()
         {
-            return new DeliveryItemListingResponse<T>(_response, _modelProvider, ApiUrl);
+            return new DeliveryItemListingResponse<T>(_response, _modelProvider);
         }
     }
 }

--- a/Kentico.Kontent.Delivery/Responses/DeliveryItemResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryItemResponse.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System;
+using System.Threading;
+using Newtonsoft.Json.Linq;
 
 namespace Kentico.Kontent.Delivery
 {
@@ -7,49 +9,48 @@ namespace Kentico.Kontent.Delivery
     /// </summary>
     public sealed class DeliveryItemResponse : AbstractResponse
     {
-        private readonly JToken _response;
         private readonly IModelProvider _modelProvider;
         private readonly IContentLinkUrlResolver _contentLinkUrlResolver;
-        private dynamic _linkedItems;
-        private ContentItem _item;
+        private readonly Lazy<ContentItem> _item;
+        private readonly Lazy<JObject> _linkedItems;
 
         /// <summary>
-        /// Gets the content item from the response.
+        /// Gets the content item.
         /// </summary>
-        public ContentItem Item
-        {
-            get { return _item ?? (_item = new ContentItem(_response["item"], _response["modular_content"], _contentLinkUrlResolver, _modelProvider)); }
-        }
+        public ContentItem Item => _item.Value;
 
         /// <summary>
         /// Gets the dynamic view of the JSON response where linked items and their properties can be retrieved by name, for example <c>LinkedItems.about_us.elements.description.value</c>.
         /// </summary>
-        public dynamic LinkedItems
-        {
-            get { return _linkedItems ?? (_linkedItems = JObject.Parse(_response["modular_content"].ToString())); }
-        }
+        public dynamic LinkedItems => _linkedItems.Value;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeliveryItemResponse"/> class with information from a response.
+        /// Initializes a new instance of the <see cref="DeliveryItemResponse"/> class.
         /// </summary>
-        /// <param name="response">A response from Kentico Kontent Delivery API that contains a content item.</param>
-        /// /// <param name="modelProvider">An instance of an object that can JSON responses into strongly typed CLR objects</param>
-        /// <param name="contentLinkUrlResolver">An instance of an object that can resolve links in rich text elements</param>
-        /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        internal DeliveryItemResponse(JToken response, IModelProvider modelProvider, IContentLinkUrlResolver contentLinkUrlResolver, string apiUrl) : base(apiUrl)
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a content item.</param>
+        /// <param name="modelProvider">The provider that can convert JSON responses into instances of .NET types.</param>
+        /// <param name="contentLinkUrlResolver">The resolver that can generate URLs for links in rich text elements.</param>
+        internal DeliveryItemResponse(ApiResponse response, IModelProvider modelProvider, IContentLinkUrlResolver contentLinkUrlResolver) : base(response)
         {
-            _response = response;
             _modelProvider = modelProvider;
             _contentLinkUrlResolver = contentLinkUrlResolver;
+            _item = new Lazy<ContentItem>(() => new ContentItem(_response.Content["item"], _response.Content["modular_content"], _contentLinkUrlResolver, _modelProvider), LazyThreadSafetyMode.PublicationOnly);
+            _linkedItems = new Lazy<JObject>(() => (JObject)_response.Content["modular_content"].DeepClone(), LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>
-        /// Casts DeliveryItemResponse to its generic version.
+        /// Casts this response to a generic one.
         /// </summary>
-        /// <typeparam name="T">Target type.</typeparam>
+        /// <typeparam name="T">The object type that the item will be deserialized to.</typeparam>
         public DeliveryItemResponse<T> CastTo<T>()
         {
-            return new DeliveryItemResponse<T>(_response, _modelProvider, ApiUrl);
+            return new DeliveryItemResponse<T>(_response, _modelProvider);
         }
+
+        /// <summary>
+        /// Implicitly converts the specified <paramref name="response"/> to a content item.
+        /// </summary>
+        /// <param name="response">The response to convert.</param>
+        public static implicit operator ContentItem(DeliveryItemResponse response) => response.Item;
     }
 }

--- a/Kentico.Kontent.Delivery/Responses/DeliveryTaxonomyListingResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryTaxonomyListingResponse.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Kentico.Kontent.Delivery
 {
@@ -9,25 +11,27 @@ namespace Kentico.Kontent.Delivery
     /// </summary>
     public sealed class DeliveryTaxonomyListingResponse : AbstractResponse
     {
+        private readonly Lazy<Pagination> _pagination;
+        private readonly Lazy<IReadOnlyList<TaxonomyGroup>> _taxonomies;
+
         /// <summary>
         /// Gets paging information.
         /// </summary>
-        public Pagination Pagination { get; }
+        public Pagination Pagination => _pagination.Value;
 
         /// <summary>
-        /// Gets a list of taxonomy groups.
+        /// Gets a read-only list of taxonomy groups.
         /// </summary>
-        public IReadOnlyList<TaxonomyGroup> Taxonomies { get; }
+        public IReadOnlyList<TaxonomyGroup> Taxonomies => _taxonomies.Value;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeliveryTaxonomyListingResponse"/> class with information from a response.
+        /// Initializes a new instance of the <see cref="DeliveryTaxonomyListingResponse"/> class.
         /// </summary>
-        /// <param name="response">A response from Kentico Kontent Delivery API that contains a list of taxonomy groups.</param>
-        /// /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        internal DeliveryTaxonomyListingResponse(JToken response, string apiUrl) : base(apiUrl)
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a list of taxonomy groups.</param>
+        internal DeliveryTaxonomyListingResponse(ApiResponse response) : base(response)
         {
-            Pagination = response["pagination"].ToObject<Pagination>();
-            Taxonomies = ((JArray)response["taxonomies"]).Select(type => new TaxonomyGroup(type)).ToList().AsReadOnly();
+            _pagination = new Lazy<Pagination>(() => _response.Content["pagination"].ToObject<Pagination>(), LazyThreadSafetyMode.PublicationOnly);
+            _taxonomies = new Lazy<IReadOnlyList<TaxonomyGroup>>(() => ((JArray)_response.Content["taxonomies"]).Select(source => new TaxonomyGroup(source)).ToList().AsReadOnly(), LazyThreadSafetyMode.PublicationOnly);
         }
     }
 }

--- a/Kentico.Kontent.Delivery/Responses/DeliveryTaxonomyResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryTaxonomyResponse.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Represents a response from Kentico Kontent Delivery API that contains a taxonomy group.
+    /// </summary>
+    public sealed class DeliveryTaxonomyResponse : AbstractResponse
+    {
+        private readonly Lazy<TaxonomyGroup> _taxonomy;
+
+        /// <summary>
+        /// Gets the taxonomy group.
+        /// </summary>
+        public TaxonomyGroup Taxonomy => _taxonomy.Value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeliveryTypeResponse"/> class.
+        /// </summary>
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a taxonomy group.</param>
+        internal DeliveryTaxonomyResponse(ApiResponse response) : base(response)
+        {
+            _taxonomy = new Lazy<TaxonomyGroup>(() => new TaxonomyGroup(_response.Content), LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        /// Implicitly converts the specified <paramref name="response"/> to a taxonomy group.
+        /// </summary>
+        /// <param name="response">The response to convert.</param>
+        public static implicit operator TaxonomyGroup(DeliveryTaxonomyResponse response) => response.Taxonomy;
+    }
+}

--- a/Kentico.Kontent.Delivery/Responses/DeliveryTypeListingResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryTypeListingResponse.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Kentico.Kontent.Delivery
 {
@@ -9,25 +11,27 @@ namespace Kentico.Kontent.Delivery
     /// </summary>
     public sealed class DeliveryTypeListingResponse : AbstractResponse
     {
+        private readonly Lazy<Pagination> _pagination;
+        private readonly Lazy<IReadOnlyList<ContentType>> _types;
+
         /// <summary>
         /// Gets paging information.
         /// </summary>
-        public Pagination Pagination { get; }
+        public Pagination Pagination => _pagination.Value;
 
         /// <summary>
-        /// Gets a list of content types.
+        /// Gets a read-only list of content types.
         /// </summary>
-        public IReadOnlyList<ContentType> Types { get; }
+        public IReadOnlyList<ContentType> Types => _types.Value;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeliveryTypeListingResponse"/> class with information from a response.
+        /// Initializes a new instance of the <see cref="DeliveryTypeListingResponse"/> class.
         /// </summary>
-        /// <param name="response">A response from Kentico Kontent Delivery API that contains a list of content types.</param>
-        /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        internal DeliveryTypeListingResponse(JToken response, string apiUrl) : base(apiUrl)
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a list of content types.</param>
+        internal DeliveryTypeListingResponse(ApiResponse response) : base(response)
         {
-            Pagination = response["pagination"].ToObject<Pagination>();
-            Types = ((JArray)response["types"]).Select(type => new ContentType(type)).ToList().AsReadOnly();
+            _pagination = new Lazy<Pagination>(() => _response.Content["pagination"].ToObject<Pagination>(), LazyThreadSafetyMode.PublicationOnly);
+            _types = new Lazy<IReadOnlyList<ContentType>>(() => ((JArray)_response.Content["types"]).Select(source => new ContentType(source)).ToList().AsReadOnly(), LazyThreadSafetyMode.PublicationOnly);
         }
     }
 }

--- a/Kentico.Kontent.Delivery/Responses/DeliveryTypeResponse.cs
+++ b/Kentico.Kontent.Delivery/Responses/DeliveryTypeResponse.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Represents a response from Kentico Kontent Delivery API that contains a content type.
+    /// </summary>
+    public sealed class DeliveryTypeResponse : AbstractResponse
+    {
+        private readonly Lazy<ContentType> _type;
+
+        /// <summary>
+        /// Gets the content type.
+        /// </summary>
+        public ContentType Type => _type.Value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeliveryTypeResponse"/> class.
+        /// </summary>
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a content type.</param>
+        internal DeliveryTypeResponse(ApiResponse response) : base(response)
+        {
+            _type = new Lazy<ContentType>(() => new ContentType(_response.Content), LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        /// Implicitly converts the specified <paramref name="response"/> to a content type.
+        /// </summary>
+        /// <param name="response">The response to convert.</param>
+        public static implicit operator ContentType(DeliveryTypeResponse response) => response.Type;
+    }
+}

--- a/Kentico.Kontent.Delivery/StrongTyping/DeliveryItemListingResponse.cs
+++ b/Kentico.Kontent.Delivery/StrongTyping/DeliveryItemListingResponse.cs
@@ -1,56 +1,48 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Kentico.Kontent.Delivery
 {
     /// <summary>
     /// Represents a response from Kentico Kontent Delivery API that contains a list of content items.
     /// </summary>
-    /// <typeparam name="T">Generic strong type of item representation.</typeparam>
+    /// <typeparam name="T">The type of content items in the response.</typeparam>
     public sealed class DeliveryItemListingResponse<T> : AbstractResponse
     {
-        private readonly JToken _response;
         private readonly IModelProvider _modelProvider;
-        private dynamic _linkedItems;
-        private Pagination _pagination;
-        private IReadOnlyList<T> _items;
+        private readonly Lazy<Pagination> _pagination;
+        private readonly Lazy<IReadOnlyList<T>> _items;
+        private readonly Lazy<JObject> _linkedItems;
 
         /// <summary>
         /// Gets paging information.
         /// </summary>
-        public Pagination Pagination
-        {
-            get { return _pagination ?? (_pagination = _response["pagination"].ToObject<Pagination>()); }
-        }
+        public Pagination Pagination => _pagination.Value;
 
         /// <summary>
-        /// Gets a list of content items.
+        /// Gets a read-only list of content items.
         /// </summary>
-        public IReadOnlyList<T> Items
-        {
-            get { return _items ?? (_items = ((JArray)_response["items"]).Select(source => _modelProvider.GetContentItemModel<T>(source, _response["modular_content"])).ToList().AsReadOnly()); }
-        }
-
+        public IReadOnlyList<T> Items => _items.Value;
 
         /// <summary>
         /// Gets the dynamic view of the JSON response where linked items and their properties can be retrieved by name, for example <c>LinkedItems.about_us.elements.description.value</c>.
         /// </summary>
-        public dynamic LinkedItems
-        {
-            get { return _linkedItems ?? (_linkedItems = JObject.Parse(_response["modular_content"].ToString())); }
-        }
+        public dynamic LinkedItems => _linkedItems.Value;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DeliveryItemListingResponse"/> class with information from a response.
+        /// Initializes a new instance of the <see cref="DeliveryItemListingResponse{T}"/> class.
         /// </summary>
-        /// <param name="response">A response from Kentico Kontent Delivery API that contains a list of content items.</param>
-        /// <param name="modelProvider"></param>
-        /// <param name="apiUrl">API URL used to communicate with the underlying Kentico Kontent endpoint.</param>
-        internal DeliveryItemListingResponse(JToken response, IModelProvider modelProvider, string apiUrl) : base(apiUrl)
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a list of content items.</param>
+        /// <param name="modelProvider">The provider that can convert JSON responses into instances of .NET types.</param>
+        internal DeliveryItemListingResponse(ApiResponse response, IModelProvider modelProvider) : base(response)
         {
-            _response = response;
             _modelProvider = modelProvider;
+            _pagination = new Lazy<Pagination>(() => _response.Content["pagination"].ToObject<Pagination>(), LazyThreadSafetyMode.PublicationOnly);
+            _items = new Lazy<IReadOnlyList<T>>(() => ((JArray)_response.Content["items"]).Select(source => _modelProvider.GetContentItemModel<T>(source, _response.Content["modular_content"])).ToList().AsReadOnly(), LazyThreadSafetyMode.PublicationOnly);
+            _linkedItems = new Lazy<JObject>(() => (JObject)_response.Content["modular_content"].DeepClone(), LazyThreadSafetyMode.PublicationOnly);
         }
     }
 }

--- a/Kentico.Kontent.Delivery/StrongTyping/DeliveryItemResponse.cs
+++ b/Kentico.Kontent.Delivery/StrongTyping/DeliveryItemResponse.cs
@@ -1,45 +1,45 @@
 ﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Threading;
 
 namespace Kentico.Kontent.Delivery
 {
     /// <summary>
-    /// Represents a response from Kentico Kontent Delivery API that contains an content items.
+    /// Represents a response from Kentico Kontent Delivery API that contains a content item.
     /// </summary>
-    /// <typeparam name="T">Generic strong type of item representation.</typeparam>
+    /// <typeparam name="T">The type of a content item in the response.</typeparam>
     public sealed class DeliveryItemResponse<T> : AbstractResponse
     {
-        private readonly JToken _response;
         private readonly IModelProvider _modelProvider;
-        private dynamic _linkedItems;
-        private T _item;
+        private readonly Lazy<T> _item;
+        private readonly Lazy<JObject> _linkedItems;
 
         /// <summary>
-        /// Gets a content item.
+        /// Gets the content item.
         /// </summary>
-        public T Item
-        {
-            get
-            {
-                if (_item == null)
-                {
-                    _item = _modelProvider.GetContentItemModel<T>(_response["item"], _response["modular_content"]);
-                }
-                return _item;
-            }
-        }
+        public T Item => _item.Value;
 
         /// <summary>
         /// Gets the dynamic view of the JSON response where linked items and their properties can be retrieved by name, for example <c>LinkedItems.about_us.elements.description.value</c>.
         /// </summary>
-        public dynamic LinkedItems
+        public dynamic LinkedItems => _linkedItems.Value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeliveryItemResponse{T}"/> class.
+        /// </summary>
+        /// <param name="response">The response from Kentico Kontent Delivery API that contains a content item.</param>
+        /// <param name="modelProvider">The provider that can convert JSON responses into instances of .NET types.</param>
+        internal DeliveryItemResponse(ApiResponse response, IModelProvider modelProvider) : base(response)
         {
-            get { return _linkedItems ?? (_linkedItems = JObject.Parse(_response["modular_content"].ToString())); }
+            _modelProvider = modelProvider;
+            _item = new Lazy<T>(() => _modelProvider.GetContentItemModel<T>(_response.Content["item"], _response.Content["modular_content"]), LazyThreadSafetyMode.PublicationOnly);
+            _linkedItems = new Lazy<JObject>(() => (JObject)_response.Content["modular_content"].DeepClone(), LazyThreadSafetyMode.PublicationOnly);
         }
 
-        internal DeliveryItemResponse(JToken response, IModelProvider modelProvider, string apiUrl) : base(apiUrl)
-        {
-            _response = response;
-            _modelProvider = modelProvider;
-        }
+        /// <summary>
+        /// Implicitly converts the specified <paramref name="response"/> to a content item.
+        /// </summary>
+        /// <param name="response">The response to convert.</param>
+        public static implicit operator T(DeliveryItemResponse<T> response) => response.Item;
     }
 }


### PR DESCRIPTION
### Motivation

To improve response times Delivery API might provide stale content. Stale means that there is a more recent version, but it will become available later. This information is important for developers who implement caching because stale content should have a short TTL.

Developers can inspect the value of the **X-Stale-Content** response header. **1** indicates that content is stale. With SDK developers can also inspect the value of the **HasStaleContent** property of response objects.

This feature introduced a breaking change. Documentation will be updated independently.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

There is no need for manual testing.