### PR TITLE
Support for IncludeTotalCount parameter

### DIFF
--- a/Kentico.Kontent.Delivery.Tests/Builders/DeliveryOptions/DeliveryOptionsBuilderTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Builders/DeliveryOptions/DeliveryOptionsBuilderTests.cs
@@ -110,6 +110,19 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.DeliveryOptions
         }
 
         [Fact]
+        public void BuildWithIncludeTotalCount()
+        {
+            var deliveryOptions = DeliveryOptionsBuilder
+                .CreateInstance()
+                .WithProjectId(Guid.NewGuid())
+                .UseProductionApi()
+                .IncludeTotalCount()
+                .Build();
+
+            Assert.True(deliveryOptions.IncludeTotalCount);
+        }
+
+        [Fact]
         public void BuildWithCustomEndpointForPreviewApi()
         {
             const string customEndpoint = "http://www.customPreviewEndpoint.com";

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -412,10 +412,10 @@ namespace Kentico.Kontent.Delivery.Tests
         public async void QueryParameters()
         {
 
-            string url = $"{_baseUrl}/items?elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name=Hario%20V60&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&depth=2&elements=price%2Cproduct_name&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en";
+            string url = $"{_baseUrl}/items?elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name=Hario%20V60&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&depth=2&elements=price%2Cproduct_name&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en&includeTotalCount";
             _mockHttp
                 .When($"{url}")
-                .Respond("application/json", " { 'items': [],'modular_content': {},'pagination': {'skip': 2,'limit': 10,'count': 0,'next_page': ''}}");
+                .Respond("application/json", " { 'items': [],'modular_content': {},'pagination': {'skip': 2,'limit': 10,'count': 0, 'total_count': 0, 'next_page': ''}}");
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
 
@@ -436,7 +436,8 @@ namespace Kentico.Kontent.Delivery.Tests
                 new LimitParameter(10),
                 new OrderParameter("elements.price", SortOrder.Descending),
                 new SkipParameter(2),
-                new LanguageParameter("en")
+                new LanguageParameter("en"),
+                new IncludeTotalCountParameter()
            };
 
             var response = await client.GetItemsAsync(parameters);

--- a/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
     <PackageReference Include="Castle.Windsor" Version="4.1.1" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="3.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
@@ -49,7 +49,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
         {
             var existingParams = new List<IQueryParameter>() { new SkipParameter(15) };
 
-            var enhancedParams = new List<IQueryParameter>(_client.ExtractParameters<TypeWithContentTypeCodename>(existingParams));
+            var enhancedParams = new List<IQueryParameter>(_client.EnsureContentTypeFilter<TypeWithContentTypeCodename>(existingParams));
 
             Assert.Equal(2, enhancedParams.Count);
             Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);
@@ -58,7 +58,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
         [Fact]
         public void ExtractParameters_WhenGivenTypeWithCodename_CreatesNewParams()
         {
-            var enhancedParams = new List<IQueryParameter>(_client.ExtractParameters<TypeWithContentTypeCodename>());
+            var enhancedParams = new List<IQueryParameter>(_client.EnsureContentTypeFilter<TypeWithContentTypeCodename>());
 
             Assert.Single(enhancedParams);
             Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);
@@ -67,7 +67,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
         [Fact]
         public void ExtractParameters_WhenGivenTypeWithoutCodenameNoParams_CreatesEmptyParams()
         {
-            var enhancedParams = new List<IQueryParameter>(_client.ExtractParameters<TypeWithoutContentTypeCodename>());
+            var enhancedParams = new List<IQueryParameter>(_client.EnsureContentTypeFilter<TypeWithoutContentTypeCodename>());
 
             Assert.Empty(enhancedParams);
         }
@@ -77,7 +77,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
         {
             var existingParams = new List<IQueryParameter>() { new SkipParameter(15) };
 
-            var enhancedParams = new List<IQueryParameter>(_client.ExtractParameters<TypeWithoutContentTypeCodename>(existingParams));
+            var enhancedParams = new List<IQueryParameter>(_client.EnsureContentTypeFilter<TypeWithoutContentTypeCodename>(existingParams));
 
             Assert.Single(enhancedParams);
             Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type=TypeWithoutContentTypeCodename") == null);
@@ -88,7 +88,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
         {
             var existingParams = new List<IQueryParameter>() { new EqualsFilter("system.type", CONTENT_TYPE_CODENAME) };
 
-            var enhancedParams = new List<IQueryParameter>(_client.ExtractParameters<TypeWithContentTypeCodename>(existingParams));
+            var enhancedParams = new List<IQueryParameter>(_client.EnsureContentTypeFilter<TypeWithContentTypeCodename>(existingParams));
 
             Assert.Single(enhancedParams);
             Assert.True(enhancedParams.Find(x => x.GetQueryStringParameter() == $"system.type={CONTENT_TYPE_CODENAME}") != null);

--- a/Kentico.Kontent.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using FakeItEasy;
+using FluentAssertions;
+using Kentico.Kontent.Delivery.Tests.Factories;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace Kentico.Kontent.Delivery.Tests.QueryParameters
+{
+    public class IncludeTotalCountTests
+    {
+        private static readonly Guid ProjectId = Guid.NewGuid();
+        private static readonly string BaseUrl = $"https://deliver.kontent.ai/{ProjectId}";
+        private static readonly MockHttpMessageHandler MockHttp = new MockHttpMessageHandler();
+        private static readonly DeliveryOptions Options = new DeliveryOptions
+        {
+            ProjectId = ProjectId.ToString(),
+            EnableRetryPolicy = false,
+            IncludeTotalCount = true
+        };
+
+        [Fact]
+        public void PaginationResponse_WithoutTotalCount_DeserializedCorrectly()
+        {
+            var responsePagination = JObject.FromObject(new
+            {
+                skip = 20,
+                limit = 10,
+                count = 8,
+                next_page = "nextPage"
+            });
+            var expected = new Pagination(20, 10, 8, null, "nextPage");
+
+            var result = responsePagination.ToObject<Pagination>();
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void PaginationResponse_WithTotalCount_DeserializedCorrectly()
+        {
+            var responsePagination = JObject.FromObject(new
+            {
+                skip = 20,
+                limit = 10,
+                count = 8,
+                total_count = 28,
+                next_page = "nextPage"
+            });
+            var expected = new Pagination(20, 10, 8, 28, "nextPage");
+
+            var result = responsePagination.ToObject<Pagination>();
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async void GetItemsJson_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
+        {
+            var responseJson = JsonConvert.SerializeObject(CreateItemsResponse());
+            MockHttp
+                .Expect($"{BaseUrl}/items")
+                .WithExactQueryString("includeTotalCount")
+                .Respond("application/json", responseJson);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+
+            await client.GetItemsJsonAsync();
+
+            MockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async void GetItems_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
+        {
+            var responseJson = JsonConvert.SerializeObject(CreateItemsResponse());
+            MockHttp
+                .Expect($"{BaseUrl}/items")
+                .WithExactQueryString("includeTotalCount")
+                .Respond("application/json", responseJson);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+
+            await client.GetItemsAsync();
+
+            MockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async void GetItemsTyped_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
+        {
+            var responseJson = JsonConvert.SerializeObject(CreateItemsResponse());
+            MockHttp
+                .Expect($"{BaseUrl}/items")
+                .WithExactQueryString("system.type=cafe&includeTotalCount")
+                .Respond("application/json", responseJson);
+            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+            A.CallTo(() => client.TypeProvider.GetCodename(typeof(Cafe))).Returns("cafe");
+
+            await client.GetItemsAsync<Cafe>();
+
+            MockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        private static object CreateItemsResponse() => new
+        {
+            items = new object[0],
+            modular_content = new { },
+            pagination = new
+            {
+                skip = 0,
+                limit = 0,
+                count = 1,
+                total_count = 1,
+                next_page = ""
+            }
+        };
+    }
+}

--- a/Kentico.Kontent.Delivery/Builders/DeliveryOptions/DeliveryOptionsBuilder.cs
+++ b/Kentico.Kontent.Delivery/Builders/DeliveryOptions/DeliveryOptionsBuilder.cs
@@ -16,7 +16,7 @@ namespace Kentico.Kontent.Delivery
         public static IDeliveryOptionsBuilder CreateInstance()
             => new DeliveryOptionsBuilder();
 
-        private DeliveryOptionsBuilder() {}
+        private DeliveryOptionsBuilder() { }
 
         IDeliveryApiConfiguration IDeliveryOptionsBuilder.WithProjectId(string projectId)
         {
@@ -37,6 +37,13 @@ namespace Kentico.Kontent.Delivery
         IOptionalDeliveryConfiguration IOptionalDeliveryConfiguration.WaitForLoadingNewContent()
         {
             _deliveryOptions.WaitForLoadingNewContent = true;
+
+            return this;
+        }
+
+        IOptionalDeliveryConfiguration IOptionalDeliveryConfiguration.IncludeTotalCount()
+        {
+            _deliveryOptions.IncludeTotalCount = true;
 
             return this;
         }

--- a/Kentico.Kontent.Delivery/Builders/DeliveryOptions/IDeliveryOptionsBuilder.cs
+++ b/Kentico.Kontent.Delivery/Builders/DeliveryOptions/IDeliveryOptionsBuilder.cs
@@ -59,13 +59,12 @@ namespace Kentico.Kontent.Delivery.Builders.DeliveryOptions
         /// However, the request might take longer than usual to complete.
         /// </summary>
         IOptionalDeliveryConfiguration WaitForLoadingNewContent();
-        
+
         /// <summary>
-        /// Provide information on how many items are there in total for a query to items endpoint.
-        /// This can be used to determine total number of pages that can be retrieved.
-        /// We don't recommend to enable this setting for all requests as this might increase response time.
+        /// Include the total number of items matching the search criteria in the response.
+        /// This behavior can also be enabled for individual requests with the <see cref="IncludeTotalCountParameter"/>.
+        /// Please note that using this option might increase the response time.
         /// </summary>
-        /// <returns></returns>
         IOptionalDeliveryConfiguration IncludeTotalCount();
         
         /// <summary>

--- a/Kentico.Kontent.Delivery/Builders/DeliveryOptions/IDeliveryOptionsBuilder.cs
+++ b/Kentico.Kontent.Delivery/Builders/DeliveryOptions/IDeliveryOptionsBuilder.cs
@@ -59,7 +59,15 @@ namespace Kentico.Kontent.Delivery.Builders.DeliveryOptions
         /// However, the request might take longer than usual to complete.
         /// </summary>
         IOptionalDeliveryConfiguration WaitForLoadingNewContent();
-
+        
+        /// <summary>
+        /// Provide information on how many items are there in total for a query to items endpoint.
+        /// This can be used to determine total number of pages that can be retrieved.
+        /// We don't recommend to enable this setting for all requests as this might increase response time.
+        /// </summary>
+        /// <returns></returns>
+        IOptionalDeliveryConfiguration IncludeTotalCount();
+        
         /// <summary>
         /// Change configuration of the default retry policy.
         /// </summary>

--- a/Kentico.Kontent.Delivery/Configuration/DeliveryOptions .cs
+++ b/Kentico.Kontent.Delivery/Configuration/DeliveryOptions .cs
@@ -61,5 +61,11 @@
         /// Gets or sets configuration of the default retry policy.
         /// </summary>
         public DefaultRetryPolicyOptions DefaultRetryPolicyOptions { get; set; } = new DefaultRetryPolicyOptions();
+
+        /// <summary>
+        /// Gets or sets a value that determines if the client provides total count for each query to items.
+        /// This can also be enabled on per request basis by query parameter <see cref="IncludeTotalCountParameter"/>.
+        /// </summary>
+        public bool IncludeTotalCount { get; set; }
     }
 }

--- a/Kentico.Kontent.Delivery/Configuration/DeliveryOptions .cs
+++ b/Kentico.Kontent.Delivery/Configuration/DeliveryOptions .cs
@@ -63,8 +63,8 @@
         public DefaultRetryPolicyOptions DefaultRetryPolicyOptions { get; set; } = new DefaultRetryPolicyOptions();
 
         /// <summary>
-        /// Gets or sets a value that determines if the client provides total count for each query to items.
-        /// This can also be enabled on per request basis by query parameter <see cref="IncludeTotalCountParameter"/>.
+        /// Gets or sets a value that determines if the client includes the total number of items matching the search criteria in response.
+        /// This behavior can also be enabled for individual requests with the <see cref="IncludeTotalCountParameter"/>.
         /// </summary>
         public bool IncludeTotalCount { get; set; }
     }

--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -207,7 +207,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemListingResponse{T}"/> instance that contains the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<DeliveryItemListingResponse<T>> GetItemsAsync<T>(IEnumerable<IQueryParameter> parameters)
         {
-            var enhancedParameters = ExtractParameters<T>(parameters).ToList();
+            var enhancedParameters = EnsureContentTypeFilter<T>(parameters).ToList();
             var endpointUrl = UrlBuilder.GetItemsUrl(enhancedParameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
@@ -261,7 +261,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemsFeed{T}"/> instance that can be used to enumerate through content items. If no query parameters are specified, all content items are enumerated.</returns>
         public IDeliveryItemsFeed<T> GetItemsFeed<T>(IEnumerable<IQueryParameter> parameters)
         {
-            var enhancedParameters = ExtractParameters<T>(parameters).ToList();
+            var enhancedParameters = EnsureContentTypeFilter<T>(parameters).ToList();
             ValidateItemsFeedParameters(enhancedParameters);
             var endpointUrl = UrlBuilder.GetItemsFeedUrl(enhancedParameters);
             return new DeliveryItemsFeed<T>(GetItemsBatchAsync);
@@ -555,7 +555,7 @@ namespace Kentico.Kontent.Delivery
             return httpResponseMessage.Headers.TryGetValues("X-Stale-Content", out var values) && values.Contains("1", StringComparer.Ordinal);
         }
 
-        internal IEnumerable<IQueryParameter> ExtractParameters<T>(IEnumerable<IQueryParameter> parameters = null)
+        internal IEnumerable<IQueryParameter> EnsureContentTypeFilter<T>(IEnumerable<IQueryParameter> parameters = null)
         {
             var enhancedParameters = parameters != null
                 ? new List<IQueryParameter>(parameters)

--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -93,13 +93,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="JObject"/> instance that represents the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<JObject> GetItemsJsonAsync(params string[] parameters)
         {
-            var parameterList = parameters?.ToList() ?? new List<string>();
-            if (DeliveryOptions.IncludeTotalCount && !parameterList.Contains(new IncludeTotalCountParameter().GetQueryStringParameter()))
-            {
-                parameterList.Add(new IncludeTotalCountParameter().GetQueryStringParameter());
-            }
-
-            var endpointUrl = UrlBuilder.GetItemsUrl(parameterList.ToArray());
+            var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
 
             return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
@@ -188,13 +182,7 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemListingResponse"/> instance that contains the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<DeliveryItemListingResponse> GetItemsAsync(IEnumerable<IQueryParameter> parameters)
         {
-            var parameterList = parameters?.ToList() ?? new List<IQueryParameter>();
-            if (DeliveryOptions.IncludeTotalCount && !parameterList.Any(x => x is IncludeTotalCountParameter))
-            {
-                parameterList.Add(new IncludeTotalCountParameter());
-            }
-
-            var endpointUrl = UrlBuilder.GetItemsUrl(parameterList);
+            var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
             return new DeliveryItemListingResponse(response, ModelProvider, ContentLinkUrlResolver);
@@ -220,10 +208,6 @@ namespace Kentico.Kontent.Delivery
         public async Task<DeliveryItemListingResponse<T>> GetItemsAsync<T>(IEnumerable<IQueryParameter> parameters)
         {
             var enhancedParameters = ExtractParameters<T>(parameters).ToList();
-            if (DeliveryOptions.IncludeTotalCount && !enhancedParameters.Any(x => x is IncludeTotalCountParameter))
-            {
-                enhancedParameters.Add(new IncludeTotalCountParameter());
-            }
             var endpointUrl = UrlBuilder.GetItemsUrl(enhancedParameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 

--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -93,7 +93,13 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="JObject"/> instance that represents the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<JObject> GetItemsJsonAsync(params string[] parameters)
         {
-            var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
+            var parameterList = parameters?.ToList() ?? new List<string>();
+            if (DeliveryOptions.IncludeTotalCount && !parameterList.Contains(new IncludeTotalCountParameter().GetQueryStringParameter()))
+            {
+                parameterList.Add(new IncludeTotalCountParameter().GetQueryStringParameter());
+            }
+
+            var endpointUrl = UrlBuilder.GetItemsUrl(parameterList.ToArray());
 
             return (await GetDeliverResponseAsync(endpointUrl)).Content;
         }
@@ -182,7 +188,13 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemListingResponse"/> instance that contains the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<DeliveryItemListingResponse> GetItemsAsync(IEnumerable<IQueryParameter> parameters)
         {
-            var endpointUrl = UrlBuilder.GetItemsUrl(parameters);
+            var parameterList = parameters?.ToList() ?? new List<IQueryParameter>();
+            if (DeliveryOptions.IncludeTotalCount && !parameterList.Any(x => x is IncludeTotalCountParameter))
+            {
+                parameterList.Add(new IncludeTotalCountParameter());
+            }
+
+            var endpointUrl = UrlBuilder.GetItemsUrl(parameterList);
             var response = await GetDeliverResponseAsync(endpointUrl);
 
             return new DeliveryItemListingResponse(response, ModelProvider, ContentLinkUrlResolver);
@@ -207,7 +219,11 @@ namespace Kentico.Kontent.Delivery
         /// <returns>The <see cref="DeliveryItemListingResponse{T}"/> instance that contains the content items. If no query parameters are specified, all content items are returned.</returns>
         public async Task<DeliveryItemListingResponse<T>> GetItemsAsync<T>(IEnumerable<IQueryParameter> parameters)
         {
-            var enhancedParameters = ExtractParameters<T>(parameters);
+            var enhancedParameters = ExtractParameters<T>(parameters).ToList();
+            if (DeliveryOptions.IncludeTotalCount && !enhancedParameters.Any(x => x is IncludeTotalCountParameter))
+            {
+                enhancedParameters.Add(new IncludeTotalCountParameter());
+            }
             var endpointUrl = UrlBuilder.GetItemsUrl(enhancedParameters);
             var response = await GetDeliverResponseAsync(endpointUrl);
 

--- a/Kentico.Kontent.Delivery/DeliveryEndpointUrlBuilder.cs
+++ b/Kentico.Kontent.Delivery/DeliveryEndpointUrlBuilder.cs
@@ -35,12 +35,14 @@ namespace Kentico.Kontent.Delivery
 
         public string GetItemsUrl(string[] parameters)
         {
-            return GetUrl(UrlTemplateItems, parameters);
+            var enrichedParameters = EnrichParameters(parameters).ToArray();
+            return GetUrl(UrlTemplateItems, enrichedParameters);
         }
 
         public string GetItemsUrl(IEnumerable<IQueryParameter> parameters)
         {
-            return GetUrl(UrlTemplateItems, parameters);
+            var updatedParameters = EnrichParameters(parameters);
+            return GetUrl(UrlTemplateItems, updatedParameters);
         }
 
         public string GetItemsFeedUrl(string[] parameters)
@@ -137,6 +139,28 @@ namespace Kentico.Kontent.Delivery
             var projectId = Uri.EscapeDataString(_deliveryOptions.ProjectId);
             var hostUrl = string.Format(endpointUrlTemplate, projectId);
             return hostUrl;
+        }
+
+        private IEnumerable<string> EnrichParameters(IEnumerable<string> parameters)
+        {
+            var parameterList = parameters?.ToList() ?? new List<string>();
+            if (_deliveryOptions.IncludeTotalCount && !parameterList.Contains(new IncludeTotalCountParameter().GetQueryStringParameter()))
+            {
+                parameterList.Add(new IncludeTotalCountParameter().GetQueryStringParameter());
+            }
+
+            return parameterList;
+        }
+
+        private IEnumerable<IQueryParameter> EnrichParameters(IEnumerable<IQueryParameter> parameters)
+        {
+            var parameterList = parameters?.ToList() ?? new List<IQueryParameter>();
+            if (_deliveryOptions.IncludeTotalCount && !parameterList.Any(x => x is IncludeTotalCountParameter))
+            {
+                parameterList.Add(new IncludeTotalCountParameter());
+            }
+
+            return parameterList;
         }
     }
 }

--- a/Kentico.Kontent.Delivery/Models/Pagination.cs
+++ b/Kentico.Kontent.Delivery/Models/Pagination.cs
@@ -23,6 +23,11 @@ namespace Kentico.Kontent.Delivery
         public int Count { get; }
 
         /// <summary>
+        /// Gets the total number of items for query.
+        /// </summary>
+        public int? TotalCount { get; }
+
+        /// <summary>
         /// Gets the URL of the next page.
         /// </summary>
         /// <remarks>The URL of the next page, if available; otherwise, <see cref="string.Empty"/>.</remarks>
@@ -32,11 +37,12 @@ namespace Kentico.Kontent.Delivery
         /// Initializes a new instance of the <see cref="Pagination"/> class with information from a response.
         /// </summary>
         [JsonConstructor]
-        internal Pagination(int skip, int limit, int count, string next_page)
+        internal Pagination(int skip, int limit, int count, int? total_count, string next_page)
         {
             Skip = skip;
             Limit = limit;
             Count = count;
+            TotalCount = total_count;
             NextPageUrl = next_page;
         }
     }

--- a/Kentico.Kontent.Delivery/Models/Pagination.cs
+++ b/Kentico.Kontent.Delivery/Models/Pagination.cs
@@ -23,7 +23,7 @@ namespace Kentico.Kontent.Delivery
         public int Count { get; }
 
         /// <summary>
-        /// Gets the total number of items for query.
+        /// Gets the total number of items matching the search criteria.
         /// </summary>
         public int? TotalCount { get; }
 

--- a/Kentico.Kontent.Delivery/QueryParameters/Parameters/IncludeTotalCountParameter.cs
+++ b/Kentico.Kontent.Delivery/QueryParameters/Parameters/IncludeTotalCountParameter.cs
@@ -1,0 +1,23 @@
+﻿namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// Specifies whether to include total count in the paging section.
+    /// </summary>
+    public sealed class IncludeTotalCountParameter : IQueryParameter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncludeTotalCountParameter"/> class.
+        /// </summary>
+        public IncludeTotalCountParameter()
+        {
+        }
+
+        /// <summary>
+        /// Returns the query string representation of the query parameter.
+        /// </summary>
+        public string GetQueryStringParameter()
+        {
+            return "includeTotalCount";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ DeliveryItemListingResponse response = await client.GetItemsAsync(
 );
 ```
 
-### Pagination
+### Paging navigation
 
-If you need to build a paging navigation for your items, you might need to retrieve the total number of items matching the search criteria. This can be achieved by adding `IncludeTotalCountParameter` to the request parameters. With the parameter included the `Pagination` section of the multiple content items response will contain `TotalCount` property. The parameter can also be configured globally by calling method `IncludeTotalCount()` on `IDeliveryOptionsBuilder`. This results in adding `IncludeTotalCountParameter` automatically to each request.
+To display a paging navigation you need to retrieve the total number of items matching the search criteria. This can be achieved by adding the `IncludeTotalCountParameter` to the request parameters. With this parameter the item listing responses will contain the total number of items in the `Pagination.TotalCount` property. This behavior can also be enabled globally by calling the `IDeliveryOptionsBuilder.IncludeTotalCount` method. Please note that response times might increase slightly.
 
 ```csharp
 // Retrieves the second page of items including total number of items matching the search criteria

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ DeliveryItemListingResponse response = await client.GetItemsAsync(
 );
 ```
 
+### Pagination
+
+If you need to build a paging navigation for your items, you might need to retrieve the total number of items matching the search criteria. This can be achieved by adding `IncludeTotalCountParameter` to the request parameters. With the parameter included the `Pagination` section of the multiple content items response will contain `TotalCount` property. The parameter can also be configured globally by calling method `IncludeTotalCount()` on `IDeliveryOptionsBuilder`. This results in adding `IncludeTotalCountParameter` automatically to each request.
+
+```csharp
+// Retrieves the second page of items including total number of items matching the search criteria
+DeliveryItemListingResponse response = await client.GetItemsAsync(
+    new LanguageParameter("es-ES"),
+    new EqualsFilter("system.type", "brewer"),
+    new OrderParameter("elements.product_name"),
+    new SkipParameter(5),
+    new LimitParameter(5),
+    new IncludeTotalCountParameter(),
+```
+
 ### Strongly-typed responses
 
 The `IDeliveryClient` also supports retrieving of strongly-typed models.


### PR DESCRIPTION
### Motivation

Support the new feature of the Delivery API to include total items count in paging response.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Automatic tests
