### PR TITLE
Delivery client factory

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/IDeliveryClientFactory.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/IDeliveryClientFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Delivery.Abstractions
+{
+    /// <summary>
+    /// Defines a methods for getting a <see cref="IDeliveryClient"/>
+    /// </summary>
+    public interface IDeliveryClientFactory
+    {
+        /// <summary>
+        /// Returns a named <see cref="IDeliveryClient"/>.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns>The <see cref="IDeliveryClient"/> instance that represents named client</returns>
+        IDeliveryClient Get(string name);
+
+        /// <summary>
+        /// Returns an <see cref="IDeliveryClient"/>.
+        /// </summary>
+        /// <returns>The <see cref="IDeliveryClient"/> instance that represents client</returns>
+        IDeliveryClient Get();
+    }
+}

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -14,6 +14,7 @@ using Kentico.Kontent.Delivery.Abstractions;
 using Kentico.Kontent.Delivery.Abstractions.RetryPolicy;
 using Kentico.Kontent.Delivery.StrongTyping;
 using Kentico.Kontent.Delivery.ContentLinks;
+using DeliveryClientFactory = Kentico.Kontent.Delivery.Tests.Factories;
 
 namespace Kentico.Kontent.Delivery.Tests
 {
@@ -797,7 +798,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 .When($"{_baseUrl}/items")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}items.json")));
 
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy())
                 .Returns(retryPolicy);
@@ -823,7 +824,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 .When($"{_baseUrl}/items")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}items.json")));
 
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             var elements = new ElementsParameter(Enumerable.Range(0, 1000000).Select(i => "test").ToArray());
 
@@ -861,7 +862,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 SecureAccessApiKey = "someKey"
             };
 
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy())
@@ -898,7 +899,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 .WithHeaders("Authorization", $"Bearer {securityKey}")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}items.json")));
 
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
 
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy())
@@ -923,7 +924,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 .WithHeaders("X-KC-SDKID", $"nuget.org;{sdkPackageId};{sdkVersion}")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}items.json")));
 
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
 
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy())
@@ -1284,7 +1285,7 @@ namespace Kentico.Kontent.Delivery.Tests
             _mockHttp
                 .When($"{_baseUrl}/items")
                 .Respond((request) => new HttpResponseMessage(HttpStatusCode.RequestTimeout));
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, _mockHttp);
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy()).Returns(retryPolicy);
             A.CallTo(() => retryPolicy.ExecuteAsync(A<Func<Task<HttpResponseMessage>>>._))
@@ -1306,7 +1307,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 ProjectId = _guid.ToString(),
                 EnableRetryPolicy = false
             };
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(options, _mockHttp);
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy()).Returns(retryPolicy);
 
@@ -1350,7 +1351,7 @@ namespace Kentico.Kontent.Delivery.Tests
                 null,
                 customTypeProvider,
                 new PropertyMapper());
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(
                 _guid,
                 handler,
                 modelProvider,
@@ -1369,7 +1370,7 @@ namespace Kentico.Kontent.Delivery.Tests
         {
             var mapper = propertyMapper ?? A.Fake<IPropertyMapper>();
             var modelProvider = new ModelProvider(null, null, _mockTypeProvider, mapper);
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, handler, modelProvider);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithProjectId(_guid, handler, modelProvider);
 
             var retryPolicy = A.Fake<IRetryPolicy>();
             A.CallTo(() => client.RetryPolicyProvider.GetRetryPolicy())

--- a/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using FakeItEasy;
 using Kentico.Kontent.Delivery.Abstractions;
 using Kentico.Kontent.Delivery.Abstractions.ContentLinks;
 using Kentico.Kontent.Delivery.Abstractions.InlineContentItems;
@@ -102,11 +103,31 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
 
             AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
         }
+        [Fact]
+        public void AddDeliveryFactoryClientWithDeliveryClient_AllServicesAreRegistered()
+        {
+            var deliveryClient = A.Fake<IDeliveryClient>();
+            _fakeServiceCollection.AddDeliveryClient("named", () => deliveryClient);
+
+            AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
+        }
 
         [Fact]
-        public void AddDeliveryFactoryClientWithNullDeliveryOptions_AllServicesAreRegistered()
+        public void AddDeliveryFactoryClientWithNullDeliveryOptions_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", deliveryOptions: null));
+        }
+
+        [Fact]
+        public void AddDeliveryFactoryClientWithNullDeliveryClient_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", configureDeliveryClient: null));
+        }
+
+        [Fact]
+        public void AddDeliveryFactoryClientWithNullDeliveryOptionsBuilder_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", buildDeliveryOptions: null));
         }
 
         [Fact]

--- a/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -103,25 +103,11 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
 
             AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
         }
-        [Fact]
-        public void AddDeliveryFactoryClientWithDeliveryClient_AllServicesAreRegistered()
-        {
-            var deliveryClient = A.Fake<IDeliveryClient>();
-            _fakeServiceCollection.AddDeliveryClient("named", () => deliveryClient);
-
-            AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
-        }
 
         [Fact]
         public void AddDeliveryFactoryClientWithNullDeliveryOptions_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", deliveryOptions: null));
-        }
-
-        [Fact]
-        public void AddDeliveryFactoryClientWithNullDeliveryClient_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", configureDeliveryClient: null));
         }
 
         [Fact]

--- a/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -8,6 +8,7 @@ using Kentico.Kontent.Delivery.Abstractions;
 using Kentico.Kontent.Delivery.Abstractions.ContentLinks;
 using Kentico.Kontent.Delivery.Abstractions.InlineContentItems;
 using Kentico.Kontent.Delivery.Abstractions.RetryPolicy;
+using Kentico.Kontent.Delivery.Configuration;
 using Kentico.Kontent.Delivery.ContentLinks;
 using Kentico.Kontent.Delivery.InlineContentItems;
 using Kentico.Kontent.Delivery.RetryPolicy;
@@ -55,8 +56,29 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
                 { typeof(IPropertyMapper), typeof(PropertyMapper) },
                 { typeof(IRetryPolicyProvider), typeof(DefaultRetryPolicyProvider) },
                 { typeof(IDeliveryClient), typeof(DeliveryClient) },
+                { typeof(IDeliveryClientFactory), typeof(DeliveryClientFactory) },
             }
         );
+
+        private readonly ReadOnlyDictionary<Type, Type> _expectedInterfacesWithImplementationFactoryTypes = new ReadOnlyDictionary<Type, Type>(
+           new Dictionary<Type, Type>
+           {
+               { typeof(IConfigureOptions<DeliveryClientFactoryOptions>), null },
+               { typeof(IContentLinkUrlResolver), typeof(DefaultContentLinkUrlResolver) },
+               { typeof(IContentLinkResolver), typeof(ContentLinkResolver) },
+               { typeof(ITypeProvider), typeof(TypeProvider) },
+               { typeof(IDeliveryHttpClient), typeof(DeliveryHttpClient) },
+               { typeof(IInlineContentItemsProcessor), typeof(InlineContentItemsProcessor) },
+               { typeof(IInlineContentItemsResolver<object>), typeof(ReplaceWithWarningAboutRegistrationResolver) },
+               { typeof(IInlineContentItemsResolver<UnretrievedContentItem>), typeof(ReplaceWithWarningAboutUnretrievedItemResolver) },
+               { typeof(IInlineContentItemsResolver<UnknownContentItem>), typeof(ReplaceWithWarningAboutUnknownItemResolver) },
+               { typeof(IModelProvider), typeof(ModelProvider) },
+               { typeof(IPropertyMapper), typeof(PropertyMapper) },
+               { typeof(IRetryPolicyProvider), typeof(DefaultRetryPolicyProvider) },
+               { typeof(IDeliveryClient), typeof(DeliveryClient) },
+               { typeof(IDeliveryClientFactory), typeof(DeliveryClientFactory) },
+           }
+   );
 
         private readonly FakeServiceCollection _fakeServiceCollection;
 
@@ -66,9 +88,31 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
         }
 
         [Fact]
+        public void AddDeliveryFactoryClientWithDeliveryOptions_AllServicesAreRegistered()
+        {
+            _fakeServiceCollection.AddDeliveryClient("named", new DeliveryOptions { ProjectId = ProjectId });
+
+            AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
+        }
+
+        [Fact]
+        public void AddDeliveryFactoryClientWithDeliveryOptionsBuilder_AllServicesAreRegistered()
+        {
+            _fakeServiceCollection.AddDeliveryClient("named", builder => builder.WithProjectId(ProjectId).UseProductionApi().Build());
+
+            AssertFactoryServiceCollection(_expectedInterfacesWithImplementationFactoryTypes, _expectedResolvableContentTypes);
+        }
+
+        [Fact]
+        public void AddDeliveryFactoryClientWithNullDeliveryOptions_AllServicesAreRegistered()
+        {
+            Assert.Throws<ArgumentNullException>(() => _fakeServiceCollection.AddDeliveryClient("named", deliveryOptions: null));
+        }
+
+        [Fact]
         public void AddDeliveryClientWithDeliveryOptions_AllServicesAreRegistered()
         {
-            _fakeServiceCollection.AddDeliveryClient(new DeliveryOptions {ProjectId = ProjectId});
+            _fakeServiceCollection.AddDeliveryClient(new DeliveryOptions { ProjectId = ProjectId });
 
             AssertDefaultServiceCollection(_expectedInterfacesWithImplementationTypes, _expectedResolvableContentTypes);
         }
@@ -136,7 +180,7 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
 
         private IDictionary<Type, Type> GetModifiedExpectedOptionsTypes()
         {
-            var excludedTypes = new [] { typeof(IOptions<DeliveryOptions>) };
+            var excludedTypes = new[] { typeof(IOptions<DeliveryOptions>) };
 
             return _expectedInterfacesWithImplementationTypes
                 .Where(pair => !excludedTypes.Contains(pair.Key))
@@ -148,7 +192,7 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
                 .Union(additionalTypes)
                 .ToArray();
 
-        private IDictionary<Type, Type> AddToExpectedInterfacesWithImplementationTypes(params (Type contract, Type implementation)[] additionalTypes) => 
+        private IDictionary<Type, Type> AddToExpectedInterfacesWithImplementationTypes(params (Type contract, Type implementation)[] additionalTypes) =>
             _expectedInterfacesWithImplementationTypes
                 .Union(additionalTypes.ToDictionary(
                     addition => addition.contract,
@@ -164,7 +208,13 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
             AssertEqualResolvableContentTypes(expectedResolvableContentTypes);
         }
 
-        private static string GetNameFromRegistration(KeyValuePair<Type, Type> registration) 
+        private void AssertFactoryServiceCollection(IDictionary<Type, Type> expectedTypes, IEnumerable<Type> expectedResolvableContentTypes)
+        {
+            AssertEqualServiceCollectionRegistrations(expectedTypes);
+            AssertEqualResolvableContentTypes(expectedResolvableContentTypes);
+        }
+
+        private static string GetNameFromRegistration(KeyValuePair<Type, Type> registration)
             => registration.Value?.FullName ?? registration.Key?.FullName;
 
         // removes types that are automatically registered by DI framework when DeliveryOptions are registered
@@ -172,6 +222,7 @@ namespace Kentico.Kontent.Delivery.Tests.Extensions
         {
             var optionsRelatedTypes = new Dictionary<Type, Type>
             {
+                {typeof(IConfigureOptions<DeliveryClientFactoryOptions>), null},
                 {typeof(IConfigureOptions<DeliveryOptions>), null},
                 {typeof(IOptionsChangeTokenSource<DeliveryOptions>), null},
                 {typeof(IOptions<>), null},

--- a/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactoryTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactoryTests.cs
@@ -1,0 +1,62 @@
+﻿using FakeItEasy;
+using FluentAssertions;
+using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Kentico.Kontent.Delivery.Tests.Factories
+{
+    public class DeliveryClientFactoryTests
+    {
+        private readonly IOptions<DeliveryOptions> _deliveryOptionsMock;
+        private readonly IOptionsMonitor<DeliveryClientFactoryOptions> _deliveryClientFactoryOptionsMock;
+        private readonly IServiceProvider _serviceProviderMock;
+
+        private const string _clientName = "ClientName";
+
+        public DeliveryClientFactoryTests()
+        {
+            _deliveryOptionsMock = A.Fake<IOptions<DeliveryOptions>>();
+            _deliveryClientFactoryOptionsMock = A.Fake<IOptionsMonitor<DeliveryClientFactoryOptions>>();
+            _serviceProviderMock = A.Fake<IServiceProvider>();
+        }
+        [Fact]
+        public void GetNamedClient_WithCorrectName_GetClient()
+        {
+            var deliveryClient = new DeliveryClient(_deliveryOptionsMock);
+            var deliveryClientFactoryOptions = new DeliveryClientFactoryOptions();
+            deliveryClientFactoryOptions.DeliveryClientsActions.Add(() => deliveryClient);
+
+            A.CallTo(() => _deliveryClientFactoryOptionsMock.Get(_clientName))
+                .Returns(deliveryClientFactoryOptions);
+
+            var deliveryClientFactory = new Delivery.DeliveryClientFactory(_deliveryClientFactoryOptionsMock, _serviceProviderMock);
+
+            var result = deliveryClientFactory.Get(_clientName);
+
+            result.Should().Be(deliveryClient);
+        }
+
+        [Fact]
+        public void GetNamedClient_WithWrongName_GetNull()
+        {
+            var deliveryClient = new DeliveryClient(_deliveryOptionsMock);
+            var deliveryClientFactoryOptions = new DeliveryClientFactoryOptions();
+            deliveryClientFactoryOptions.DeliveryClientsActions.Add(() => deliveryClient);
+
+            A.CallTo(() => _deliveryClientFactoryOptionsMock.Get(_clientName))
+                .Returns(deliveryClientFactoryOptions);
+
+            var deliveryClientFactory = new Delivery.DeliveryClientFactory(_deliveryClientFactoryOptionsMock, _serviceProviderMock);
+
+            var result = deliveryClientFactory.Get("WrongName");
+
+            result.Should().BeNull();
+        }
+    }
+}

--- a/Kentico.Kontent.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
@@ -65,7 +65,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
                 .Expect($"{BaseUrl}/items")
                 .WithExactQueryString("includeTotalCount")
                 .Respond("application/json", responseJson);
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
 
             await client.GetItemsJsonAsync();
 
@@ -80,7 +80,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
                 .Expect($"{BaseUrl}/items")
                 .WithExactQueryString("includeTotalCount")
                 .Respond("application/json", responseJson);
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
 
             await client.GetItemsAsync();
 
@@ -95,7 +95,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
                 .Expect($"{BaseUrl}/items")
                 .WithExactQueryString("system.type=cafe&includeTotalCount")
                 .Respond("application/json", responseJson);
-            var client = DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
+            var client = Factories.DeliveryClientFactory.GetMockedDeliveryClientWithOptions(Options, MockHttp);
             A.CallTo(() => client.TypeProvider.GetCodename(typeof(Cafe))).Returns("cafe");
 
             await client.GetItemsAsync<Cafe>();

--- a/Kentico.Kontent.Delivery/Configuration/DeliveryClientFactoryOptions.cs
+++ b/Kentico.Kontent.Delivery/Configuration/DeliveryClientFactoryOptions.cs
@@ -1,0 +1,18 @@
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Delivery.Configuration
+{
+    /// <summary>
+    /// Represents configuration of the <see cref="DeliveryClientFactory"/>.
+    /// </summary>
+    public class DeliveryClientFactoryOptions
+    {
+        /// <summary>
+        /// Gets a list of operations used to configure an <see cref="IDeliveryClient"/>.
+        /// </summary>
+        public IList<Func<IDeliveryClient>> DeliveryClientsActions { get; } = new List<Func<IDeliveryClient>>();
+    }
+}

--- a/Kentico.Kontent.Delivery/DeliveryClientFactory.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClientFactory.cs
@@ -20,7 +20,7 @@ namespace Kentico.Kontent.Delivery
         private readonly IServiceProvider _serviceProvider;
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="DeliveryClientFactory"/> class
         /// </summary>
         /// <param name="optionsMonitor">A <see cref="DeliveryClientFactory"/> options</param>
         /// <param name="serviceProvider">A <see cref="IServiceProvider"/> instance</param>

--- a/Kentico.Kontent.Delivery/DeliveryClientFactory.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClientFactory.cs
@@ -1,0 +1,64 @@
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Kentico.Kontent.Delivery
+{
+    /// <summary>
+    /// A factory class for <see cref="IDeliveryClient"/>
+    /// </summary>
+    public class DeliveryClientFactory  : IDeliveryClientFactory
+    {
+        private ConcurrentDictionary<string, IDeliveryClient> _cachedDeliveryClients = new ConcurrentDictionary<string, IDeliveryClient>();
+        private readonly IOptionsMonitor<DeliveryClientFactoryOptions> _optionsMonitor;
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="optionsMonitor">A <see cref="DeliveryClientFactory"/> options</param>
+        /// <param name="serviceProvider">A <see cref="IServiceProvider"/> instance</param>
+        public DeliveryClientFactory(IOptionsMonitor<DeliveryClientFactoryOptions> optionsMonitor, IServiceProvider serviceProvider)
+        {
+            _optionsMonitor = optionsMonitor;
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <summary>
+        /// Returns a named <see cref="IDeliveryClient"/>.
+        /// </summary>
+        /// <param name="name">A name of <see cref="IDeliveryClient"/> configuration</param>
+        /// <returns>The <see cref="IDeliveryClient"/> instance that represents named client</returns>
+        public IDeliveryClient Get(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (!_cachedDeliveryClients.TryGetValue(name, out var client))
+            {
+                var options = _optionsMonitor.Get(name);
+                client = options.DeliveryClientsActions.FirstOrDefault()?.Invoke();
+                _cachedDeliveryClients.TryAdd(name, client);
+            }
+
+            return client;
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IDeliveryClient"/>.
+        /// </summary>
+        /// <returns>The <see cref="IDeliveryClient"/> instance that represents client</returns>
+        public IDeliveryClient Get()
+        {
+            return _serviceProvider.GetRequiredService<IDeliveryClient>();
+        }
+    }
+}

--- a/Kentico.Kontent.Delivery/Extensions/ServiceCollectionExtensions.cs
+++ b/Kentico.Kontent.Delivery/Extensions/ServiceCollectionExtensions.cs
@@ -87,32 +87,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Registers a delegate that will be used to configure a named <see cref="IDeliveryClient"/> via <see cref="IDeliveryClientFactory"/>
-        /// </summary>
-        /// <param name="services">A <see cref="ServiceCollection"/> instance for registering and resolving dependencies.</param>
-        /// <param name="name">The name of the client configuration</param>
-        /// <param name="configureDeliveryClient">A delegate that is used to configure an <see cref="IDeliveryClient"/>.</param>
-        /// <returns></returns>
-        public static IServiceCollection AddDeliveryClient(this IServiceCollection services, string name, Func<IDeliveryClient> configureDeliveryClient)
-        {
-            if (configureDeliveryClient == null)
-            {
-                throw new ArgumentNullException(nameof(configureDeliveryClient), "The function for creating DeliveryClient is null.");
-            }
-
-            services.AddTransient<IConfigureOptions<DeliveryClientFactoryOptions>>(s =>
-            {
-                return new ConfigureNamedOptions<DeliveryClientFactoryOptions>(name, options =>
-                {
-                    options.DeliveryClientsActions.Add(configureDeliveryClient);
-                });
-
-            });
-
-            return services.RegisterDependencies();
-        }
-
-        /// <summary>
         /// Registers a <see cref="IDeliveryClient"/> instance to an <see cref="IDeliveryClient"/> interface in <see cref="ServiceCollection"/>.
         /// </summary>
         /// <param name="services">A <see cref="ServiceCollection"/> instance for registering and resolving dependencies.</param>


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #`issue number`

You can manage your IDeliveryClient from the IDeliveryClientFactory class. Now you can register more IDeliveryClient with different configurations.

For the registration, you need to use the same extension method `AddDelivery`, but the first parameter is the name of your client.
```
services.AddDeliveryClient("namedClient", new DeliveryOptions
{
    ProjectId = "7f09d7c4-f8b4-40de-ab80-b9184caa4a40",
});
```


`IDeliveryClientFactory` has two methods: 
`Get()` - You get the IDeliveryClient which is not registered as named client
`Get("name")` - You get named IDeliveryClient.


### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
