### PR TITLE
fixes CS1998 warning

### DIFF
--- a/Kentico.Kontent.Delivery.Caching/DeliveryCacheManager.cs
+++ b/Kentico.Kontent.Delivery.Caching/DeliveryCacheManager.cs
@@ -147,15 +147,14 @@ namespace Kentico.Kontent.Delivery.Caching
         /// Clears cache
         /// </summary>
         /// <returns></returns>
-        public async Task ClearAsync()
+        public Task ClearAsync()
         {
-            await Task.Run(() =>
+            foreach (var key in _createLocks.Keys)
             {
-                foreach (var key in _createLocks.Keys)
-                {
-                    _memoryCache.Remove(key);
-                }
-            });
+                _memoryCache.Remove(key);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Kentico.Kontent.Delivery.Caching/DeliveryCacheManager.cs
+++ b/Kentico.Kontent.Delivery.Caching/DeliveryCacheManager.cs
@@ -141,7 +141,6 @@ namespace Kentico.Kontent.Delivery.Caching
             {
                 tokenSource.Cancel();
             }
-
         }
 
         /// <summary>
@@ -150,10 +149,13 @@ namespace Kentico.Kontent.Delivery.Caching
         /// <returns></returns>
         public async Task ClearAsync()
         {
-            foreach (var key in _createLocks.Keys)
+            await Task.Run(() =>
             {
-                _memoryCache.Remove(key);
-            }
+                foreach (var key in _createLocks.Keys)
+                {
+                    _memoryCache.Remove(key);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
### Motivation

The `IDeliveryCacheManager` interface requires the Clear method to be async. When the implementor runs synchronously, it gives the CS1998 warning. 
This approach should solve the issue.

Related to #195 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

REbuild the solution and check the Error list pane.
