### PR TITLE
Fix mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ See [Working with Strongly Typed Models](../../wiki/Working-with-strongly-typed-
 
 For more developer resources, visit:
 * [✔️ Best practices for Delivery SDK for .NET](../../wiki)
-* Kentico Kontent Developer Hub:
-  * [.NET Tutorials](https://docs.kontent.ai/tutorials/develop-apps)
+* Kentico Kontent Docs:
+  * [.NET Tutorials](https://docs.kontent.ai/tutorials/develop-apps?tech=dotnet)
   * [API Reference](https://docs.kontent.ai/reference)
 
 ## Get involved


### PR DESCRIPTION
Removed mentions of Developer Hub and provided a more specific URL to .NET materials.