### PR TITLE
Set c# version for project to latest minor

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/Kentico.Kontent.Delivery.Abstractions.csproj
+++ b/Kentico.Kontent.Delivery.Abstractions/Kentico.Kontent.Delivery.Abstractions.csproj
@@ -17,6 +17,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery.Caching.Tests/Kentico.Kontent.Delivery.Caching.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Caching.Tests/Kentico.Kontent.Delivery.Caching.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageId>Kentico.Kontent.Delivery.Caching.Tests</PackageId>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery.Caching/Kentico.Kontent.Delivery.Caching.csproj
+++ b/Kentico.Kontent.Delivery.Caching/Kentico.Kontent.Delivery.Caching.csproj
@@ -17,6 +17,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery.Rx.Tests/Kentico.Kontent.Delivery.Rx.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Rx.Tests/Kentico.Kontent.Delivery.Rx.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageId>Kentico.Kontent.Delivery.Rx.Tests</PackageId>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
+++ b/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
@@ -17,6 +17,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
@@ -21,6 +21,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Kentico.Kontent.Delivery/Kentico.Kontent.Delivery.csproj
+++ b/Kentico.Kontent.Delivery/Kentico.Kontent.Delivery.csproj
@@ -17,6 +17,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation

There is the `is` keyword in construction:
```csharp
if (value is AbstractResponse ar && ar.HasStaleContent)
```

https://github.com/Kentico/kontent-delivery-sdk-net/blob/a1a856afe901a687d6b5a0984f809c2bab3878f2/Kentico.Kontent.Delivery.Caching/DeliveryCacheManager.cs#L70

And since the project is set to default (the latest major version of the language 7.0) build fails, because construction was added to language with one of the later versions.

I have set this for all projects.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

The successful build would be sufficient.