### PR TITLE
fixes #234 - hashcode of a cached type is now part of the cache key

### DIFF
--- a/Kentico.Kontent.Delivery.Caching.Tests/CacheHelpersTests.cs
+++ b/Kentico.Kontent.Delivery.Caching.Tests/CacheHelpersTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FluentAssertions;
 using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.Caching.Tests.ContentTypes;
 using Kentico.Kontent.Delivery.Urls.QueryParameters;
 using Kentico.Kontent.Delivery.Urls.QueryParameters.Filters;
 using Xunit;
@@ -16,11 +17,12 @@ namespace Kentico.Kontent.Delivery.Caching.Tests
         {
             var keys = new[]
             {
-                CacheHelpers.GetItemTypedKey("codename", Enumerable.Empty<IQueryParameter>()),
-                CacheHelpers.GetItemTypedKey("other_codename", Enumerable.Empty<IQueryParameter>()),
-                CacheHelpers.GetItemTypedKey("codename", new []{new DepthParameter(1)}),
-                CacheHelpers.GetItemTypedKey("codename", new [] {new DepthParameter(2) }),
-                CacheHelpers.GetItemTypedKey("codename", new []{new SystemTypeEqualsFilter("article") })
+                CacheHelpers.GetItemKey<object>("codename", Enumerable.Empty<IQueryParameter>()),
+                CacheHelpers.GetItemKey<object>("other_codename", Enumerable.Empty<IQueryParameter>()),
+                CacheHelpers.GetItemKey<object>("codename", new []{new DepthParameter(1)}),
+                CacheHelpers.GetItemKey<object>("codename", new [] {new DepthParameter(2) }),
+                CacheHelpers.GetItemKey<object>("codename", new []{new SystemTypeEqualsFilter("article") }),
+                CacheHelpers.GetItemKey<Article>("codename", new []{new SystemTypeEqualsFilter("article") })
             };
 
             keys.Distinct().Count().Should().Be(keys.Length);
@@ -31,10 +33,11 @@ namespace Kentico.Kontent.Delivery.Caching.Tests
         {
             var keys = new[]
             {
-                CacheHelpers.GetItemsTypedKey(Enumerable.Empty<IQueryParameter>()),
-                CacheHelpers.GetItemsTypedKey(new []{new DepthParameter(1)}),
-                CacheHelpers.GetItemsTypedKey(new [] {new DepthParameter(2) }),
-                CacheHelpers.GetItemsTypedKey(new []{new SystemTypeEqualsFilter("article") })
+                CacheHelpers.GetItemsKey<object>(Enumerable.Empty<IQueryParameter>()),
+                CacheHelpers.GetItemsKey<object>(new []{new DepthParameter(1)}),
+                CacheHelpers.GetItemsKey<object>(new [] {new DepthParameter(2) }),
+                CacheHelpers.GetItemsKey<object>(new []{new SystemTypeEqualsFilter("article") }) ,
+                CacheHelpers.GetItemsKey<Article>(new []{new SystemTypeEqualsFilter("article") })
             };
 
             keys.Distinct().Count().Should().Be(keys.Length);

--- a/Kentico.Kontent.Delivery.Caching/CacheHelpers.cs
+++ b/Kentico.Kontent.Delivery.Caching/CacheHelpers.cs
@@ -42,9 +42,9 @@ namespace Kentico.Kontent.Delivery.Caching
         /// <param name="codename">CodeName</param>
         /// <param name="parameters">Query parameters</param>
         /// <returns>Dependency key</returns>
-        public static string GetItemTypedKey(string codename, IEnumerable<IQueryParameter> parameters)
+        public static string GetItemKey<T>(string codename, IEnumerable<IQueryParameter> parameters)
         {
-            return StringHelpers.Join(new[] { CONTENT_ITEM_TYPED_IDENTIFIER, codename }.Concat(parameters?.Select(x => x.GetQueryStringParameter()) ?? Enumerable.Empty<string>()));
+            return StringHelpers.Join(new[] { typeof(T).GetHashCode().ToString(), CONTENT_ITEM_TYPED_IDENTIFIER, codename }.Concat(parameters?.Select(x => x.GetQueryStringParameter()) ?? Enumerable.Empty<string>()));
         }
 
         /// <summary>
@@ -52,9 +52,9 @@ namespace Kentico.Kontent.Delivery.Caching
         /// </summary>
         /// <param name="parameters">Query parameters</param>
         /// <returns>Dependency keys</returns>
-        public static string GetItemsTypedKey(IEnumerable<IQueryParameter> parameters)
+        public static string GetItemsKey<T>(IEnumerable<IQueryParameter> parameters)
         {
-            return StringHelpers.Join(new[] { CONTENT_ITEM_LISTING_TYPED_IDENTIFIER }.Concat(parameters?.Select(x => x.GetQueryStringParameter()) ?? Enumerable.Empty<string>()));
+            return StringHelpers.Join(new[] { typeof(T).GetHashCode().ToString(), CONTENT_ITEM_LISTING_TYPED_IDENTIFIER }.Concat(parameters?.Select(x => x.GetQueryStringParameter()) ?? Enumerable.Empty<string>()));
         }
 
         /// <summary>

--- a/Kentico.Kontent.Delivery.Caching/DeliveryClientCache.cs
+++ b/Kentico.Kontent.Delivery.Caching/DeliveryClientCache.cs
@@ -36,7 +36,7 @@ namespace Kentico.Kontent.Delivery.Caching
         {
             var queryParameters = parameters?.ToList();
             return await _deliveryCacheManager.GetOrAddAsync(
-                CacheHelpers.GetItemTypedKey(codename, queryParameters),
+                CacheHelpers.GetItemKey<T>(codename, queryParameters),
                 () => _deliveryClient.GetItemAsync<T>(codename, queryParameters),
                 response => response != null,
                 CacheHelpers.GetItemDependencies);
@@ -52,7 +52,7 @@ namespace Kentico.Kontent.Delivery.Caching
         {
             var queryParameters = parameters?.ToList();
             return await _deliveryCacheManager.GetOrAddAsync(
-                CacheHelpers.GetItemsTypedKey(queryParameters),
+                CacheHelpers.GetItemsKey<T>(queryParameters),
                 () => _deliveryClient.GetItemsAsync<T>(queryParameters),
                 response => response.Items.Any(),
                 CacheHelpers.GetItemsDependencies);


### PR DESCRIPTION
### Motivation

Fixes #234

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Repro steps: https://github.com/Kentico/kontent-delivery-sdk-net/issues/234#issue-685040301
