### PR TITLE
KCL-6022 - Add collection property to item system attributes

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/ContentItems/IContentItemSystemAttributes.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/ContentItems/IContentItemSystemAttributes.cs
@@ -21,5 +21,10 @@ namespace Kentico.Kontent.Delivery.Abstractions
         /// Gets the codename of the content type, for example "article".
         /// </summary>
         string Type { get; }
+
+        /// <summary>
+        /// Gets the codename of the content collection to which the content item belongs
+        /// </summary>
+        public string Collection { get; }
     }
 }

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -68,6 +68,7 @@ namespace Kentico.Kontent.Delivery.Tests
 
             Assert.Equal("article", beveragesItem.System.Type);
             Assert.Equal("en-US", beveragesItem.System.Language);
+            Assert.Equal("default", beveragesItem.System.Collection);
             Assert.NotEmpty(beveragesItem.System.SitemapLocation);
             Assert.NotEmpty(roastsItem.RelatedArticles);
             Assert.NotEmpty(roastsItem.RelatedArticlesInterface);

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/coffee_beverages_explained.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/coffee_beverages_explained.json
@@ -6,6 +6,7 @@
       "codename": "coffee_beverages_explained",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -92,6 +93,7 @@
         "codename": "americano",
         "language": "en-US",
         "type": "tweet",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-06-27T13:00:08.2735049Z"
       },
@@ -130,6 +132,7 @@
         "codename": "how_to_make_a_cappuccino",
         "language": "en-US",
         "type": "hosted_video",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-06-27T12:57:16.7333276Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/coffee_processing_techniques.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/coffee_processing_techniques.json
@@ -6,6 +6,7 @@
       "codename": "coffee_processing_techniques",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -107,6 +108,7 @@
         "codename": "which_brewing_fits_you_",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -202,6 +204,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/on_roasts.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/ContentLinkResolver/on_roasts.json
@@ -6,6 +6,7 @@
       "codename": "on_roasts",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -96,6 +97,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -182,6 +184,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/allendale.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/allendale.json
@@ -7,6 +7,7 @@
         "codename": "allendale",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -71,6 +72,7 @@
         "codename": "boston",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -135,6 +137,7 @@
         "codename": "london_",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "europe"
@@ -199,6 +202,7 @@
         "codename": "los_angeles",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -263,6 +267,7 @@
         "codename": "madrid",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "europe"
@@ -327,6 +332,7 @@
         "codename": "new_york",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles.json
@@ -7,6 +7,7 @@
         "codename": "about_us",
         "language": "en-US",
         "type": "about_us",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],
@@ -36,6 +37,7 @@
         "codename": "aeropress",
         "language": "en-US",
         "type": "brewer",
+        "collection": "default",
         "sitemap_locations": [
           "brewers"
         ],
@@ -119,6 +121,7 @@
         "codename": "how_we_source_our_coffees",
         "language": "en-US",
         "type": "fact_about_us",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],
@@ -160,6 +163,7 @@
         "codename": "how_we_roast_our_coffees",
         "language": "en-US",
         "type": "fact_about_us",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],
@@ -207,6 +211,7 @@
         "codename": "our_philosophy",
         "language": "en-US",
         "type": "fact_about_us",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed.json
@@ -7,6 +7,7 @@
         "codename": "coffee_beverages_explained",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:12:58.578Z"
       },
@@ -41,6 +42,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:13:35.312Z"
       },
@@ -79,6 +81,7 @@
         "codename": "donate_with_us",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:14:07.384Z"
       },
@@ -113,6 +116,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:21:11.38Z"
       },
@@ -151,6 +155,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:21:49.151Z"
       },
@@ -189,6 +194,7 @@
         "codename": "which_brewing_fits_you_",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:24:54.042Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed_1.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed_1.json
@@ -7,6 +7,7 @@
         "codename": "coffee_beverages_explained",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:12:58.578Z"
       },
@@ -41,6 +42,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:13:35.312Z"
       },
@@ -79,6 +81,7 @@
         "codename": "donate_with_us",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:14:07.384Z"
       },
@@ -113,6 +116,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:21:11.38Z"
       },
@@ -151,6 +155,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:21:49.151Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed_2.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/articles_feed_2.json
@@ -7,6 +7,7 @@
         "codename": "which_brewing_fits_you_",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2019-03-27T13:24:54.042Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/brazil_natural_barra_grande.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/brazil_natural_barra_grande.json
@@ -6,6 +6,7 @@
       "codename": "brazil_natural_barra_grande",
       "language": "en-US",
       "type": "coffee",
+      "collection": "default",
       "sitemap_locations": [
         "coffee"
       ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/coffee_beverages_explained.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/coffee_beverages_explained.json
@@ -6,6 +6,7 @@
       "codename": "coffee_beverages_explained",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -94,6 +95,7 @@
         "codename": "americano",
         "language": "en-US",
         "type": "tweet",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-06-27T13:00:08.2735049Z"
       },
@@ -132,6 +134,7 @@
         "codename": "how_to_make_a_cappuccino",
         "language": "en-US",
         "type": "hosted_video",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-06-27T12:57:16.7333276Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/complete_content_item.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/complete_content_item.json
@@ -6,6 +6,7 @@
       "codename": "complete_content_item",
       "language": "default",
       "type": "complete_content_type",
+      "collection": "default",
       "sitemap_locations": [],
       "last_modified": "2017-02-22T00:52:03.9370993Z"
     },
@@ -112,6 +113,7 @@
         "codename": "homepage",
         "language": "default",
         "type": "homepage",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-21T04:29:42.9564205Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/complete_content_item_system_type.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/complete_content_item_system_type.json
@@ -7,6 +7,7 @@
         "codename": "complete_content_item",
         "language": "default",
         "type": "complete_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-22T00:52:03.9370993Z"
       },
@@ -114,6 +115,7 @@
         "codename": "homepage",
         "language": "default",
         "type": "homepage",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-21T04:29:42.9564205Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/items.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/items.json
@@ -7,6 +7,7 @@
         "codename": "article_1",
         "language": "default",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-03-02T00:42:14.9675295Z"
       },
@@ -40,6 +41,7 @@
         "codename": "article_2",
         "language": "default",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-23T00:09:50.4493636Z"
       },
@@ -71,6 +73,7 @@
         "codename": "brno_office",
         "language": "default",
         "type": "office",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],
@@ -138,6 +141,7 @@
         "codename": "complete_content_item",
         "language": "default",
         "type": "complete_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-22T00:52:03.9370993Z"
       },
@@ -238,6 +242,7 @@
         "codename": "homepage",
         "language": "default",
         "type": "homepage",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-21T04:29:42.9564205Z"
       },
@@ -294,6 +299,7 @@
         "codename": "melbourne_office",
         "language": "default",
         "type": "office",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-03-16T22:43:20.7173008Z"
       },
@@ -345,6 +351,7 @@
         "codename": "multiple_modular_content_item",
         "language": "default",
         "type": "multiple_modular_contents",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-21T05:19:44.0820982Z"
       },
@@ -377,6 +384,7 @@
         "codename": "n1st_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [
           "about_us",
           "homepage"
@@ -405,6 +413,7 @@
         "codename": "n2nd_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2016-08-11T06:57:08.8322664Z"
       },
@@ -430,6 +439,7 @@
         "codename": "n3rd_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-03-01T03:55:52.8880146Z"
       },
@@ -455,6 +465,7 @@
         "codename": "test",
         "language": "default",
         "type": "",
+        "collection": "default",
         "sitemap_locations": [
           "about_us",
           "contact",
@@ -483,6 +494,7 @@
         "codename": "homepage",
         "language": "default",
         "type": "homepage",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-21T04:29:42.9564205Z"
       },
@@ -539,6 +551,7 @@
         "codename": "n1st_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [
           "about_us",
           "homepage"
@@ -567,6 +580,7 @@
         "codename": "n2nd_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2016-08-11T06:57:08.8322664Z"
       },
@@ -592,6 +606,7 @@
         "codename": "article_2",
         "language": "default",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-02-23T00:09:50.4493636Z"
       },
@@ -623,6 +638,7 @@
         "codename": "n3rd_level_modular_content",
         "language": "default",
         "type": "modular_content_type",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-03-01T03:55:52.8880146Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/on_roasts.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/on_roasts.json
@@ -6,6 +6,7 @@
       "codename": "on_roasts",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -96,6 +97,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -182,6 +184,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/onroast_recursive_inline_linked_items.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/onroast_recursive_inline_linked_items.json
@@ -6,6 +6,7 @@
       "codename": "on_roasts",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -93,6 +94,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/onroast_recursive_linked_items.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/onroast_recursive_linked_items.json
@@ -6,6 +6,7 @@
       "codename": "on_roasts",
       "language": "en-US",
       "type": "article",
+      "collection": "default",
       "sitemap_locations": [
         "articles"
       ],
@@ -96,6 +97,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -182,6 +184,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -282,6 +285,7 @@
         "codename": "which_brewing_fits_you_",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -377,6 +381,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -466,6 +471,7 @@
         "codename": "a_chemex_method",
         "language": "en-US",
         "type": "hosted_video",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-06-27T12:56:41.1882715Z"
       },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/rich_text_complex_tables.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/rich_text_complex_tables.json
@@ -6,6 +6,7 @@
       "codename": "rich_text_complex_tables",
       "language": "en-US",
       "type": "simple_rich_text",
+      "collection": "default",
       "sitemap_locations": [],
       "last_modified": "2020-03-16T17:49:42.7165723Z"
     },

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/home.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/home.json
@@ -6,6 +6,7 @@
       "codename": "home",
       "language": "en-US",
       "type": "home",
+      "collection": "default",
       "sitemap_locations": [
         "home"
       ],
@@ -71,6 +72,7 @@
         "codename": "new_york",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -135,6 +137,7 @@
         "codename": "boston",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -199,6 +202,7 @@
         "codename": "home_page_promotion",
         "language": "en-US",
         "type": "hero_unit",
+        "collection": "default",
         "sitemap_locations": [],
         "last_modified": "2017-03-22T12:40:16.8440029Z"
       },
@@ -238,6 +242,7 @@
         "codename": "our_story",
         "language": "en-US",
         "type": "fact_about_us",
+        "collection": "default",
         "sitemap_locations": [
           "about_us"
         ],
@@ -285,6 +290,7 @@
         "codename": "origins_of_arabica_bourbon",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -371,6 +377,7 @@
         "codename": "on_roasts",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -460,6 +467,7 @@
         "codename": "allendale",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -524,6 +532,7 @@
         "codename": "los_angeles",
         "language": "en-US",
         "type": "cafe",
+        "collection": "default",
         "sitemap_locations": [
           "cafes",
           "north_america"
@@ -588,6 +597,7 @@
         "codename": "coffee_beverages_explained",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -673,6 +683,7 @@
         "codename": "donate_with_us",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -755,6 +766,7 @@
         "codename": "coffee_processing_techniques",
         "language": "en-US",
         "type": "article",
+        "collection": "default",
         "sitemap_locations": [
           "articles"
         ],
@@ -855,6 +867,7 @@
         "codename": "home_page_hero_unit",
         "language": "en-US",
         "type": "hero_unit",
+        "collection": "default",
         "sitemap_locations": [
           "home"
         ],

--- a/Kentico.Kontent.Delivery/ContentItems/ContentItemSystemAttributes.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/ContentItemSystemAttributes.cs
@@ -37,6 +37,10 @@ namespace Kentico.Kontent.Delivery.ContentItems
         /// <inheritdoc/>
         [JsonProperty("language")]
         public string Language { get; internal set; }
+        
+        /// <inheritdoc/>
+        [JsonProperty("collection")]
+        public string Collection { get; internal set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentItemSystemAttributes"/> class.


### PR DESCRIPTION
### Motivation

The deliver will soon support sending collection information within the item.system property.
feature release ETA: 25.11


### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
* Test on [QA environment](https://kentico.atlassian.net/wiki/spaces/~ondrejch/pages/1328447611/Kentico+Kontent+environments+endpoints)
* ProjectId: 85f65fa3-6561-019a-9c96-785401add00f
* The project contains 4 collections with codenames: _default_, _contentcollection1_, _contentcollection2_, _emptycollection_
* The user should be able to filter by collection system property
  * Each collection should contain at least one item except _emptycollection_
* Each item system property should contain collection property
* The null value for collection is not valid!
* Both **preview** and **live** endpoints should be returning collection property 
