### PR TITLE
251 issue/Provide_better_access_to_error_messages

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/SharedModels/IApiResponse.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/SharedModels/IApiResponse.cs
@@ -26,5 +26,15 @@
         /// Gets the URL used to retrieve this response for debugging purposes.
         /// </summary>
         string RequestUrl { get; }
+
+        /// <summary>
+        /// Indicates whether a call to Kentico Kontent Delivery API was successful or not.
+        /// </summary>
+        bool IsSuccess { get; }
+
+        /// <summary>
+        /// Gets error object with message, error code.
+        /// </summary>
+        IError Error { get; }
     }
 }

--- a/Kentico.Kontent.Delivery.Abstractions/SharedModels/IError.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/SharedModels/IError.cs
@@ -1,0 +1,28 @@
+﻿namespace Kentico.Kontent.Delivery.Abstractions
+{
+    /// <summary>
+    /// Represents a faulty JSON response from Kentico Kontent Delivery API.
+    /// </summary>
+    public interface IError
+    {
+        /// <summary>
+        /// Gets error Message.
+        /// </summary>
+        string Message { get; }
+
+        /// <summary>
+        /// Gets the ID of a request that can be used for troubleshooting.
+        /// </summary>
+        string RequestId { get; }
+
+        /// <summary>
+        /// Gets Kentico Kontent Delivery API error code. Check the Message property for more information
+        /// </summary>
+        int ErrorCode { get; }
+
+        /// <summary>
+        /// Gets specific code of error.
+        /// </summary>
+        int SpecificCode { get; }
+    }
+}

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/no_elements.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/no_elements.json
@@ -1,0 +1,26 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "3eb5191f-4ce1-4965-bffb-87d8f3cdca08",
+        "name": "New York",
+        "codename": "new_york",
+        "language": "en-US",
+        "type": "cafe",
+        "collection": "default",
+        "sitemap_locations": [
+          "cafes",
+          "north_america"
+        ],
+        "last_modified": "2016-09-05T14:14:08.4285085Z"
+      }
+    }
+  ],
+  "modular_content": {},
+  "pagination": {
+    "skip": 0,
+    "limit": 0,
+    "count": 6,
+    "next_page": ""
+  }
+}

--- a/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
@@ -75,6 +75,9 @@
     <None Update="Fixtures\DeliveryClient\complete_content_item_system_type_feed.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\DeliveryClient\no_elements.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\DeliveryClient\rich_text_complex_tables.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Kentico.Kontent.Delivery/ContentItems/DeliveryItemResponse.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/DeliveryItemResponse.cs
@@ -25,11 +25,5 @@ namespace Kentico.Kontent.Delivery.ContentItems
         {
             Item = item;
         }
-
-        /// <summary>
-        /// Implicitly converts the specified <paramref name="response"/> to a content item.
-        /// </summary>
-        /// <param name="response">The response to convert.</param>
-        public static implicit operator T(DeliveryItemResponse<T> response) => response.Item;
     }
 }

--- a/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
@@ -79,7 +79,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
         internal async Task<object> GetContentItemModelAsync(Type modelType, JToken serializedItem, JObject linkedItems, Dictionary<string, object> processedItems = null, HashSet<RichTextContentElements> currentlyResolvedRichStrings = null)
         {
             processedItems ??= new Dictionary<string, object>();
-            IContentItemSystemAttributes itemSystemAttributes = serializedItem["system"].ToObject<IContentItemSystemAttributes>(Serializer);
+            IContentItemSystemAttributes itemSystemAttributes = serializedItem?["system"]?.ToObject<IContentItemSystemAttributes>(Serializer);
 
             var instance = CreateInstance(modelType, ref itemSystemAttributes, ref processedItems);
             if (instance == null)
@@ -155,16 +155,16 @@ namespace Kentico.Kontent.Delivery.ContentItems
             if (detectedModelType == typeof(object) || detectedModelType.IsInterface)
             {
                 // Try to find a more specific type or a type that can be instantiated
-                detectedModelType = TypeProvider?.GetType(itemSystemAttributes.Type);
+                detectedModelType = TypeProvider?.GetType(itemSystemAttributes?.Type);
             }
 
-            if (detectedModelType == null)
+            if (detectedModelType == null || itemSystemAttributes == null)
             {
                 return null;
             }
 
             var instance = Activator.CreateInstance(detectedModelType);
-            if (!processedItems.ContainsKey(itemSystemAttributes.Codename))
+            if (!processedItems.ContainsKey(itemSystemAttributes?.Codename))
             {
                 processedItems.Add(itemSystemAttributes.Codename, instance);
             }
@@ -174,10 +174,10 @@ namespace Kentico.Kontent.Delivery.ContentItems
 
         private static JObject GetElementData(JToken serializedItem)
         {
-            var elementsData = (JObject)serializedItem["elements"];
+            var elementsData = (JObject)serializedItem?["elements"];
             if (elementsData == null)
             {
-                throw new InvalidOperationException("Missing elements node in the content item data.");
+                return null;
             }
 
             return elementsData;
@@ -263,7 +263,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
         }
 
         private (string Name, JObject Value)? GetElementData(JObject elementsData, PropertyInfo property, IContentItemSystemAttributes itemSystemAttributes)
-        => elementsData.Properties()?.Where(p => PropertyMapper.IsMatch(property, p.Name, itemSystemAttributes?.Type)).Select(p => (p.Name, (JObject)p.Value)).FirstOrDefault();
+        => elementsData?.Properties()?.Where(p => PropertyMapper.IsMatch(property, p.Name, itemSystemAttributes?.Type)).Select(p => (p.Name, (JObject)p.Value)).FirstOrDefault();
 
         private static bool IsGenericHierarchicalField(Type fieldType)
         {

--- a/Kentico.Kontent.Delivery/DeliveryException.cs
+++ b/Kentico.Kontent.Delivery/DeliveryException.cs
@@ -24,19 +24,9 @@ namespace Kentico.Kontent.Delivery
         /// Initializes a new instance of the <see cref="DeliveryException"/> class with information from an error response.
         /// </summary>
         /// <param name="response">The unsuccessful response.</param>
-        /// <param name="responseStr">The error response.</param>
-        public DeliveryException(HttpResponseMessage response, string responseStr)
+        public DeliveryException(HttpResponseMessage response)
         {
-            StatusCode = response.StatusCode;
-
-            try
-            {
-                Message = JObject.Parse(responseStr)["message"].ToString();
-            }
-            catch (Exception)
-            {
-                Message = $"Unknown error. HTTP status code: {StatusCode}. Reason phrase: {response.ReasonPhrase}.";
-            }
+            Message = $"Unknown error. HTTP status code: {response?.StatusCode}. Reason phrase: {response?.ReasonPhrase}.";
         }
     }
 }

--- a/Kentico.Kontent.Delivery/SharedModels/ApiResponse.cs
+++ b/Kentico.Kontent.Delivery/SharedModels/ApiResponse.cs
@@ -43,6 +43,12 @@ namespace Kentico.Kontent.Delivery.SharedModels
         /// <inheritdoc/>
         public string RequestUrl { get; }
 
+        /// <inheritdoc/>
+        public bool IsSuccess { get => Error == null; }
+
+        /// <inheritdoc/>
+        public IError Error { get; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse"/> class.
         /// </summary>
@@ -50,12 +56,19 @@ namespace Kentico.Kontent.Delivery.SharedModels
         /// <param name="hasStaleContent">Specifies whether content is stale.</param>
         /// <param name="continuationToken">Continuation token to be used for continuing enumeration.</param>
         /// <param name="requestUrl">URL used to retrieve this response.</param>
-        internal ApiResponse(HttpContent httpContent, bool hasStaleContent, string continuationToken, string requestUrl)
+        internal ApiResponse(HttpContent httpContent, bool hasStaleContent, string continuationToken, string requestUrl) : 
+            this(httpContent, hasStaleContent, continuationToken, requestUrl, null)
+        {
+        }
+
+
+        internal ApiResponse(HttpContent httpContent, bool hasStaleContent, string continuationToken, string requestUrl, IError error)
         {
             HttpContent = httpContent;
             HasStaleContent = hasStaleContent;
             ContinuationToken = continuationToken;
             RequestUrl = requestUrl;
+            Error = error;
         }
 
         /// <summary>
@@ -65,13 +78,15 @@ namespace Kentico.Kontent.Delivery.SharedModels
         /// <param name="hasStaleContent">Specifies whether content is stale.</param>
         /// <param name="continuationToken">Continuation token to be used for continuing enumeration.</param>
         /// <param name="requestUrl">URL used to retrieve this response.</param>
+        /// <param name="error">Object that contains info about possible API error</param>
         [JsonConstructor]
-        internal ApiResponse(string content, bool hasStaleContent, string continuationToken, string requestUrl)
+        internal ApiResponse(string content, bool hasStaleContent, string continuationToken, string requestUrl, IError error)
         {
             Content = content;
             HasStaleContent = hasStaleContent;
             ContinuationToken = continuationToken;
             RequestUrl = requestUrl;
+            Error = error;
         }
 
         /// <summary>
@@ -79,7 +94,7 @@ namespace Kentico.Kontent.Delivery.SharedModels
         /// </summary>
         public async Task<JObject> GetJsonContentAsync()
         {
-            if (_jsonContent == null)
+            if (_jsonContent == null && IsSuccess)
             {
                 using var streamReader = new HttpRequestStreamReader(await HttpContent.ReadAsStreamAsync(), Encoding.UTF8);
                 using var jsonReader = new JsonTextReader(streamReader);

--- a/Kentico.Kontent.Delivery/SharedModels/Error.cs
+++ b/Kentico.Kontent.Delivery/SharedModels/Error.cs
@@ -1,0 +1,24 @@
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using Newtonsoft.Json;
+
+namespace Kentico.Kontent.Delivery.SharedModels
+{
+    internal sealed class Error : IError
+    {
+        /// <inheritdoc/>
+        [JsonProperty("message")]
+        public string Message { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("request_id")]
+        public string RequestId { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("error_code")]
+        public int ErrorCode { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("specific_code")]
+        public int SpecificCode { get; internal set; }
+    }
+}


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #251

 - IApiResponse enriched by IError and IsSuccess properties 
 - Updated and extended unit tests
 -  small changes

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

1. create a sample app
2. call DeliveryClient.GetItemAsync
