### PR TITLE
Return codename strings instead of "null" when object detail not retu…

### DIFF
--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -105,7 +105,48 @@ namespace Kentico.Kontent.Delivery.Tests
             Assert.NotEmpty(beveragesResponse.Item.TeaserImage);
             Assert.NotEmpty(beveragesResponse.Item.Personas);
         }
+        [Fact]
+        public async Task GetLinkedItemsWithDepthZeroReturnsCodenames()
+        {
+            // Arrange
+            _mockHttp
+                .When($"{_baseUrl}/items/home")
+                .Respond("application/json",
+                    await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory,
+                        $"Fixtures{Path.DirectorySeparatorChar}home_depth0.json")));
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp, new PropertyMapper(), new CustomTypeProvider());
 
+            // Act
+            var homeResponse = await client.GetItemAsync<Home>("home");
+
+            // Assert
+            Assert.True(homeResponse?.ApiResponse?.IsSuccess);
+            Assert.NotEmpty(homeResponse.Item.HeroUnit);
+            Assert.Equal(2, homeResponse.Item.HeroUnit.Count());
+            Assert.True(homeResponse.Item.HeroUnit.First() is string);
+            Assert.Equal("home_page_hero_unit", homeResponse.Item.HeroUnit.First());
+        }
+        [Fact]
+        public async Task GetLinkedItemsWithDepthOneReturnsObjects()
+        {
+            // Arrange
+            _mockHttp
+                .When($"{_baseUrl}/items/home")
+                .Respond("application/json",
+                    await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory,
+                        $"Fixtures{Path.DirectorySeparatorChar}home.json")));
+            var client = InitializeDeliveryClientWithCustomModelProvider(_mockHttp, new PropertyMapper(), new CustomTypeProvider());
+
+            // Act
+            var homeResponse = await client.GetItemAsync<Home>("home");
+
+            // Assert
+            Assert.True(homeResponse?.ApiResponse?.IsSuccess);
+            Assert.NotEmpty(homeResponse.Item.HeroUnit);
+            Assert.Equal(2, homeResponse.Item.HeroUnit.Count());
+            Assert.True(homeResponse.Item.HeroUnit.First() is HeroUnit);
+            Assert.Equal("home_page_hero_unit", ((HeroUnit)homeResponse.Item.HeroUnit.First()).System.Codename);
+        }
         [Fact]
         public async Task GetPagination()
         {

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -670,7 +670,9 @@ namespace Kentico.Kontent.Delivery.Tests
 
             Assert.NotNull(onRoastsItem.TeaserImage.First().Description);
             Assert.Equal(2, onRoastsItem.RelatedArticles.Count());
-            Assert.Empty(((Article)onRoastsItem.RelatedArticles.First()).RelatedArticles);
+            Assert.Equal(2, ((Article)onRoastsItem.RelatedArticles.First()).RelatedArticles.Count());
+            Assert.Equal(onRoastsItem, ((Article)onRoastsItem.RelatedArticles.First()).RelatedArticles.First() );
+            Assert.Equal("which_brewing_fits_you_", ((Article)onRoastsItem.RelatedArticles.First()).RelatedArticles.ElementAt(1) );
             Assert.Empty(((Article)onRoastsItem.RelatedArticles.ElementAt(1)).RelatedArticles);
         }
 

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/home_depth0.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/home_depth0.json
@@ -1,0 +1,148 @@
+{
+  "item": {
+      "system": {
+          "id": "1bd6ba00-4bf2-4a2b-8334-917faa686f66",
+          "name": "Home",
+          "codename": "home",
+          "language": "en-US",
+          "type": "home",
+          "collection": "default",
+          "sitemap_locations": [],
+          "last_modified": "2019-03-27T13:16:25.038Z",
+          "workflow_step": "published"
+      },
+      "elements": {
+          "hero_unit": {
+              "type": "modular_content",
+              "name": "Hero unit",
+              "value": [
+                  "home_page_hero_unit",
+                  "home_page_promotion"
+              ]
+          },
+          "articles": {
+              "type": "modular_content",
+              "name": "Articles",
+              "value": [
+                  "coffee_beverages_explained",
+                  "donate_with_us",
+                  "origins_of_arabica_bourbon",
+                  "on_roasts",
+                  "coffee_processing_techniques"
+              ]
+          },
+          "our_story": {
+              "type": "modular_content",
+              "name": "Our story",
+              "value": [
+                  "our_story"
+              ]
+          },
+          "cafes": {
+              "type": "modular_content",
+              "name": "Cafes",
+              "value": [
+                  "allendale",
+                  "boston",
+                  "los_angeles",
+                  "new_york"
+              ]
+          },
+          "contact": {
+              "type": "rich_text",
+              "name": "Contact",
+              "images": {},
+              "links": {},
+              "modular_content": [],
+              "value": "<h3>Contact</h3>\n<p>(+1) 123-456-7890</p>\n<p><a href=\"http://dancinggoat@localhost.local\">dancinggoat@localhost.local</a></p>\n<p><br></p>\n<p>Dancing Goat Ltd<br>\n62 E Lake St Chicago,<br>\nIllinois 60601, USA</p>"
+          },
+          "url_pattern": {
+              "type": "url_slug",
+              "name": "URL pattern",
+              "value": "dancing-goat-freshest-coffee-on-the-block"
+          },
+          "sitemap": {
+              "type": "taxonomy",
+              "name": "Sitemap",
+              "taxonomy_group": "sitemap_538125f",
+              "value": [
+                  {
+                      "name": "Home",
+                      "codename": "home"
+                  }
+              ]
+          },
+          "metadata__meta_title": {
+              "type": "text",
+              "name": "Meta title",
+              "value": "Dancing Goat–Freshest coffee on the block!"
+          },
+          "metadata__meta_description": {
+              "type": "text",
+              "name": "Meta description",
+              "value": "Visit your local Goat for the best beans in your town."
+          },
+          "metadata__og_title": {
+              "type": "text",
+              "name": "og:title",
+              "value": "Dancing Goat–Freshest coffee on the block!"
+          },
+          "metadata__og_description": {
+              "type": "text",
+              "name": "og:description",
+              "value": "Visit your local Goat for the best beans in your town."
+          },
+          "metadata__og_image": {
+              "type": "asset",
+              "name": "og:image",
+              "value": [
+                  {
+                      "name": "cafe01.jpg",
+                      "description": "Dancing Goat Café - London",
+                      "type": "image/jpeg",
+                      "size": 493724,
+                      "url": "https://assets-us-01.kc-usercontent.com:443/bec62227-085f-0009-a83e-886d318384d1/8fccb3b9-a507-48cc-bccd-0639d7fb69ec/cafe01.jpg",
+                      "width": 849,
+                      "height": 565
+                  }
+              ]
+          },
+          "metadata__twitter_site": {
+              "type": "text",
+              "name": "twitter:site",
+              "value": "Dancing Goat"
+          },
+          "metadata__twitter_creator": {
+              "type": "text",
+              "name": "twitter:creator",
+              "value": "@kenticoCloud"
+          },
+          "metadata__twitter_title": {
+              "type": "text",
+              "name": "twitter:title",
+              "value": "Dancing Goat–Freshest coffee on the block!"
+          },
+          "metadata__twitter_description": {
+              "type": "text",
+              "name": "twitter:description",
+              "value": "Visit your local Goat for the best beans in your town."
+          },
+          "metadata__twitter_image": {
+              "type": "asset",
+              "name": "twitter:image",
+              "value": [
+                  {
+                      "name": "cafe01.jpg",
+                      "description": "Dancing Goat Café - London",
+                      "type": "image/jpeg",
+                      "size": 493724,
+                      "url": "https://assets-us-01.kc-usercontent.com:443/bec62227-085f-0009-a83e-886d318384d1/8fccb3b9-a507-48cc-bccd-0639d7fb69ec/cafe01.jpg",
+                      "width": 849,
+                      "height": 565
+                  }
+              ]
+          }
+      }
+  },
+  "modular_content": {}
+}

--- a/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
+++ b/Kentico.Kontent.Delivery.Tests/Kentico.Kontent.Delivery.Tests.csproj
@@ -14,10 +14,14 @@
 
   <ItemGroup>
     <None Remove="Fixtures\home.json" />
+    <None Remove="Fixtures\home_depth0.json" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="Fixtures\home.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\home_depth0.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 | Paradigm        | Package | Downloads | Compatibility | Documentation |
 | ------------- |:-------------:| :-------------:|  :-------------:|  :-------------:|
-| Async         | [![NuGet](https://img.shields.io/nuget/v/Kentico.Kontent.Delivery.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery) | [![NuGet](https://img.shields.io/nuget/dt/Kentico.Kontent.delivery.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery) | [`netstandard2.0`](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) | [📖](#using-the-deliveryclient) |
-| Reactive      | [![NuGet](https://img.shields.io/nuget/v/Kentico.Kontent.Delivery.Rx.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery.Rx) | [![NuGet](https://img.shields.io/nuget/dt/Kentico.Kontent.delivery.Rx.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery.Rx) | [`netstandard2.0`](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) | [📖](../../wiki/Using-the-Kentico.Kontent.Delivery.Rx-reactive-library) |
+| Async         | [![NuGet](https://img.shields.io/nuget/v/Kentico.Kontent.Delivery.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery) | [![NuGet](https://img.shields.io/nuget/dt/Kentico.Kontent.delivery.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery) | [`netstandard2.0`](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) | [📖 Wiki](../../wiki) |
+| Reactive      | [![NuGet](https://img.shields.io/nuget/v/Kentico.Kontent.Delivery.Rx.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery.Rx) | [![NuGet](https://img.shields.io/nuget/dt/Kentico.Kontent.delivery.Rx.svg)](https://www.nuget.org/packages/Kentico.Kontent.Delivery.Rx) | [`netstandard2.0`](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) | [📖 Wiki](../../wiki/Using-the-Kentico.Kontent.Delivery.Rx-reactive-library) |
 
 ## Summary
 


### PR DESCRIPTION
Return codename strings instead of "null" when object detail not returned in the modular_content

### Motivation

Fixes #279 

Returns the codename string instead of null (or a messy skeleton object that looks like a content item with no content) for items that are excluded from the modular_content by the depth parameter on the API call. This means that the website can use that codename to later retrieve the detail for the content item if it is needed.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
