### PR TITLE
279 - enable to write a second value converter for the same field

### DIFF
--- a/Kentico.Kontent.Delivery.Caching.Tests/TestItem.cs
+++ b/Kentico.Kontent.Delivery.Caching.Tests/TestItem.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using Kentico.Kontent.Delivery.Abstractions;
-using Kentico.Kontent.Delivery.ContentItems;
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.ContentItems.Attributes;
 
 namespace Kentico.Kontent.Delivery.Caching.Tests
 {

--- a/Kentico.Kontent.Delivery.Caching.Tests/TestItem.cs
+++ b/Kentico.Kontent.Delivery.Caching.Tests/TestItem.cs
@@ -1,9 +1,12 @@
-﻿using Kentico.Kontent.Delivery.Abstractions;
+﻿using System;
+using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.ContentItems;
 
 namespace Kentico.Kontent.Delivery.Caching.Tests
 {
     public class TestItem
     {
+        [PropertyName("property_name_does_not_affect_caching")]
         public string Title { get; set; }
         public IContentItemSystemAttributes System { get; set; }
     }

--- a/Kentico.Kontent.Delivery.Tests/Models/ContentTypes/Article.cs
+++ b/Kentico.Kontent.Delivery.Tests/Models/ContentTypes/Article.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using Kentico.Kontent.Delivery.Abstractions;
-using Kentico.Kontent.Delivery.ContentItems;
+using Kentico.Kontent.Delivery.ContentItems.Attributes;
 using Newtonsoft.Json;
 using NodaTime;
 
@@ -29,7 +29,7 @@ namespace Kentico.Kontent.Delivery.Tests.Models.ContentTypes
 
         [PropertyName("related_articles")]
         public List<IArticle> RelatedArticlesInterface { get; set; }
-        
+
         [PropertyName("related_articles")]
         [TestLinkedItemCodenamesValueConverter]
         public List<string> RelatedArticleCodenames { get; set; }

--- a/Kentico.Kontent.Delivery.Tests/Models/ContentTypes/Article.cs
+++ b/Kentico.Kontent.Delivery.Tests/Models/ContentTypes/Article.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.ContentItems;
 using Newtonsoft.Json;
 using NodaTime;
 
@@ -7,10 +8,10 @@ namespace Kentico.Kontent.Delivery.Tests.Models.ContentTypes
 {
     public partial class Article : IArticle
     {
-        [JsonProperty("body_copy")]
+        [PropertyName("body_copy")]
         public IRichTextContent BodyCopyRichText { get; set; }
 
-        [JsonProperty("title")]
+        [PropertyName("title")]
         [TestGreeterValueConverter]
         public string TitleConverted { get; set; }
 
@@ -22,11 +23,15 @@ namespace Kentico.Kontent.Delivery.Tests.Models.ContentTypes
         [TestGreeterValueConverter]
         public string TitleNotIgnored { get; set; }
 
-        [JsonProperty("post_date")]
+        [PropertyName("post_date")]
         [NodaTimeValueConverter]
         public ZonedDateTime PostDateNodaTime { get; set; }
 
-        [JsonProperty("related_articles")]
-        public IEnumerable<IArticle> RelatedArticlesInterface { get; set; }
+        [PropertyName("related_articles")]
+        public List<IArticle> RelatedArticlesInterface { get; set; }
+        
+        [PropertyName("related_articles")]
+        [TestLinkedItemCodenamesValueConverter]
+        public List<string> RelatedArticleCodenames { get; set; }
     }
 }

--- a/Kentico.Kontent.Delivery/ContentItems/Attributes/PropertyNameAttribute.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/Attributes/PropertyNameAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Kentico.Kontent.Delivery.ContentItems
+namespace Kentico.Kontent.Delivery.ContentItems.Attributes
 {
     /// <summary>
     /// Instructs the <see cref="PropertyMapper"/> to always map to the property with the specified name.

--- a/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
@@ -225,6 +225,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
                         "date_time" => await GetElementModelAsync<ContentElementValue<DateTime>, DateTime>(property, context, elementValue, valueConverter),
                         "multiple_choice" => await GetElementModelAsync<ContentElementValue<List<MultipleChoiceOption>>, List<MultipleChoiceOption>>(property, context, elementValue, valueConverter),
                         "taxonomy" => await GetElementModelAsync<TaxonomyElementValue, IEnumerable<ITaxonomyTerm>>(property, context, elementValue, valueConverter),
+                        "modular_content" => await GetElementModelAsync<ContentElementValue<List<string>>, List<string>>(property, context, elementValue, valueConverter),
                         // Custom element, text element, URL slug element
                         _ => await GetElementModelAsync<ContentElementValue<string>, string>(property, context, elementValue, valueConverter),
                     };

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using Kentico.Kontent.Delivery.Abstractions;
 using Newtonsoft.Json;
@@ -24,6 +25,13 @@ namespace Kentico.Kontent.Delivery.ContentItems
             {
                 // If JsonIgnore is set, do not match
                 return false;
+            }
+
+            PropertyNameAttribute fieldNameAttr = modelProperty.GetCustomAttribute<PropertyNameAttribute>();
+            if (fieldNameAttr != null)
+            {
+                // Try to get the name of the field from the field name attribute
+                return fieldName.Equals(fieldNameAttr.PropertyName, StringComparison.Ordinal);
             }
 
             JsonPropertyAttribute propertyAttr = modelProperty.GetCustomAttribute<JsonPropertyAttribute>();

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
@@ -27,13 +27,13 @@ namespace Kentico.Kontent.Delivery.ContentItems
                 return false;
             }
 
-            var propertyName = GetPropertyName(modelProperty);
+            var propertyName = GetPropertyNameFromAttribute(modelProperty);
             return propertyName != null
                 ? fieldName.Equals(propertyName, StringComparison.Ordinal)
                 : fieldName.Replace("_", "").Equals(modelProperty.Name, StringComparison.OrdinalIgnoreCase); // Default mapping
         }
 
-        private static string GetPropertyName(PropertyInfo modelProperty)
+        private static string GetPropertyNameFromAttribute(PropertyInfo modelProperty)
             => modelProperty.GetCustomAttribute<PropertyNameAttribute>()?.PropertyName  // Try to get the name of the property name attribute
             ?? modelProperty.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName; // Try to get the name of JSON serialization property
     }

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.ContentItems.Attributes;
 using Newtonsoft.Json;
 
 namespace Kentico.Kontent.Delivery.ContentItems

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
@@ -34,7 +34,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
         }
 
         private static string GetPropertyName(PropertyInfo modelProperty)
-            => modelProperty.GetCustomAttribute<PropertyNameAttribute>()?.PropertyName  // Try to get the name of the field name attribute
+            => modelProperty.GetCustomAttribute<PropertyNameAttribute>()?.PropertyName  // Try to get the name of the property name attribute
             ?? modelProperty.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName; // Try to get the name of JSON serialization property
     }
 }

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyMapper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using Kentico.Kontent.Delivery.Abstractions;
 using Newtonsoft.Json;
@@ -27,22 +26,14 @@ namespace Kentico.Kontent.Delivery.ContentItems
                 return false;
             }
 
-            PropertyNameAttribute fieldNameAttr = modelProperty.GetCustomAttribute<PropertyNameAttribute>();
-            if (fieldNameAttr != null)
-            {
-                // Try to get the name of the field from the field name attribute
-                return fieldName.Equals(fieldNameAttr.PropertyName, StringComparison.Ordinal);
-            }
-
-            JsonPropertyAttribute propertyAttr = modelProperty.GetCustomAttribute<JsonPropertyAttribute>();
-            if (propertyAttr != null)
-            {
-                // Try to get the name of the field from the JSON serialization property
-                return fieldName.Equals(propertyAttr.PropertyName, StringComparison.Ordinal);
-            }
-
-            // Default mapping
-            return fieldName.Replace("_", "").Equals(modelProperty.Name, StringComparison.OrdinalIgnoreCase);
+            var propertyName = GetPropertyName(modelProperty);
+            return propertyName != null
+                ? fieldName.Equals(propertyName, StringComparison.Ordinal)
+                : fieldName.Replace("_", "").Equals(modelProperty.Name, StringComparison.OrdinalIgnoreCase); // Default mapping
         }
+
+        private static string GetPropertyName(PropertyInfo modelProperty)
+            => modelProperty.GetCustomAttribute<PropertyNameAttribute>()?.PropertyName  // Try to get the name of the field name attribute
+            ?? modelProperty.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName; // Try to get the name of JSON serialization property
     }
 }

--- a/Kentico.Kontent.Delivery/ContentItems/PropertyNameAttribute.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/PropertyNameAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Kentico.Kontent.Delivery.ContentItems
+{
+    /// <summary>
+    /// Instructs the <see cref="PropertyMapper"/> to always map to the property with the specified name.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class PropertyNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets the name of the property.
+        /// </summary>
+        /// <value>The name of the property.</value>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyNameAttribute"/> class.
+        /// </summary>
+        public PropertyNameAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Fixes #279. Enables to write a second value converter for the same field and adds a way to map to Kontent content item field without interfering with Newtonsoft JSON serializer. Can be used for example for linked item codenames as is demonstrated in this PR

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

