### PR TITLE
#318 Add config option for default rendition preset to be applied (KCL-8387)

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/Configuration/DeliveryOptions.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/Configuration/DeliveryOptions.cs
@@ -67,6 +67,12 @@
         public bool IncludeTotalCount { get; set; }
 
         /// <summary>
+        /// Gets or sets a value of codename for the rendition preset to be applied by default to the base asset URL path.
+        /// If no value is specified, asset URLs will always point to non-customized variant of the image.
+        /// </summary>
+        public string DefaultRenditionPreset { get; set; }
+
+        /// <summary>
         /// The name of the service configuration this options object is related to.
         /// </summary>
         internal string Name { get; set; }

--- a/Kentico.Kontent.Delivery.Abstractions/ContentItems/Elements/IAssetElementValue.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/ContentItems/Elements/IAssetElementValue.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Kentico.Kontent.Delivery.Abstractions
+{
+    /// <summary>
+    /// An object representing a asset element value.
+    /// </summary>
+    public interface IAssetElementValue : IContentElementValue<IEnumerable<IAsset>>
+    {
+    }
+}

--- a/Kentico.Kontent.Delivery.Abstractions/Extensions/DeliveryOptionsExtensions.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/Extensions/DeliveryOptionsExtensions.cs
@@ -24,6 +24,7 @@
             o.DefaultRetryPolicyOptions = options.DefaultRetryPolicyOptions;
             o.IncludeTotalCount = options.IncludeTotalCount;
             o.Name = options.Name;
+            o.DefaultRenditionPreset = options.DefaultRenditionPreset;
         }
     }
 }

--- a/Kentico.Kontent.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
+++ b/Kentico.Kontent.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
@@ -197,7 +197,7 @@ namespace Kentico.Kontent.Delivery.Rx.Tests
             var contentPropertyMapper = new PropertyMapper();
             var contentTypeProvider = new CustomTypeProvider();
             var serializer = new DeliveryJsonSerializer();
-            var modelProvider = new ModelProvider(contentLinkUrlResolver, contentItemsProcessor, contentTypeProvider, contentPropertyMapper, serializer, new HtmlParser());
+            var modelProvider = new ModelProvider(contentLinkUrlResolver, contentItemsProcessor, contentTypeProvider, contentPropertyMapper, serializer, new HtmlParser(), deliveryOptions);
             var retryPolicy = A.Fake<IRetryPolicy>();
             var retryPolicyProvider = A.Fake<IRetryPolicyProvider>();
             A.CallTo(() => retryPolicyProvider.GetRetryPolicy()).Returns(retryPolicy);

--- a/Kentico.Kontent.Delivery.Tests/Builders/Configuration/DeliveryOptionsBuilderTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/Builders/Configuration/DeliveryOptionsBuilderTests.cs
@@ -26,7 +26,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .UseProductionApi()
                 .Build();
 
-            Assert.Equal(deliveryOptions.ProjectId, ProjectId);
+            Assert.Equal(ProjectId, deliveryOptions.ProjectId);
             Assert.False(deliveryOptions.UsePreviewApi);
             Assert.False(deliveryOptions.UseSecureAccess);
         }
@@ -71,7 +71,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .WithDefaultRetryPolicyOptions(retryOptions)
                 .Build();
 
-            Assert.Equal(deliveryOptions.DefaultRetryPolicyOptions, retryOptions);
+            Assert.Equal(retryOptions, deliveryOptions.DefaultRetryPolicyOptions);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .WithCustomEndpoint(customEndpoint)
                 .Build();
 
-           Assert.Equal(deliveryOptions.PreviewEndpoint, customEndpoint);
+           Assert.Equal(customEndpoint, deliveryOptions.PreviewEndpoint);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .WithCustomEndpoint(customEndpoint)
                 .Build();
 
-            Assert.Equal(deliveryOptions.ProductionEndpoint, customEndpoint);
+            Assert.Equal(customEndpoint, deliveryOptions.ProductionEndpoint);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .WithCustomEndpoint(uri)
                 .Build();
 
-            Assert.Equal(deliveryOptions.PreviewEndpoint, customEndpoint);
+            Assert.Equal(customEndpoint, deliveryOptions.PreviewEndpoint);
         }
 
         [Fact]
@@ -183,7 +183,22 @@ namespace Kentico.Kontent.Delivery.Tests.Builders.Configuration
                 .WithCustomEndpoint(uri)
                 .Build();
 
-            Assert.Equal(deliveryOptions.ProductionEndpoint, customEndpoint);
+            Assert.Equal(customEndpoint, deliveryOptions.ProductionEndpoint);
+        }
+        
+        [Fact]
+        public void BuildWithDefaultRenditionPreset()
+        {
+            const string renditionPreset = "mobile";
+
+            var deliveryOptions = DeliveryOptionsBuilder
+                .CreateInstance()
+                .WithProjectId(ProjectId)
+                .UseProductionApi()
+                .WithDefaultRenditionPreset(renditionPreset)
+                .Build();
+
+            Assert.Equal(renditionPreset, deliveryOptions.DefaultRenditionPreset);
         }
     }
 }

--- a/Kentico.Kontent.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/ContentLinkResolverTests.cs
@@ -134,7 +134,7 @@ namespace Kentico.Kontent.Delivery.Tests
             var resiliencePolicyProvider = new DefaultRetryPolicyProvider(options);
             var contentLinkUrlResolver = new CustomContentLinkUrlResolver();
             var contentItemsProcessor = InlineContentItemsProcessorFactory.Create();
-            var modelProvider = new ModelProvider(contentLinkUrlResolver, contentItemsProcessor, new CustomTypeProvider(), new PropertyMapper(), new DeliveryJsonSerializer(), new HtmlParser());
+            var modelProvider = new ModelProvider(contentLinkUrlResolver, contentItemsProcessor, new CustomTypeProvider(), new PropertyMapper(), new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
             var client = new DeliveryClient(
                 deliveryOptions,
                 modelProvider,

--- a/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactory.cs
+++ b/Kentico.Kontent.Delivery.Tests/Factories/DeliveryClientFactory.cs
@@ -21,7 +21,7 @@ namespace Kentico.Kontent.Delivery.Tests.Factories
             var httpClient = GetHttpClient(httpMessageHandler);
 
             var client = new DeliveryClient(
-                DeliveryOptionsFactory.CreateMonitor(new DeliveryOptions { ProjectId = projectId.ToString() }),
+                DeliveryOptionsFactory.CreateMonitor(projectId),
                 modelProvider ?? A.Fake<IModelProvider>(),
                 resiliencePolicyProvider ?? A.Fake<IRetryPolicyProvider>(),
                 typeProvider ?? A.Fake<ITypeProvider>(),

--- a/Kentico.Kontent.Delivery.Tests/Factories/DeliveryOptionsFactory.cs
+++ b/Kentico.Kontent.Delivery.Tests/Factories/DeliveryOptionsFactory.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using System;
+using FakeItEasy;
 using Kentico.Kontent.Delivery.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -11,6 +12,11 @@ namespace Kentico.Kontent.Delivery.Tests.Factories
             var mock = A.Fake<IOptionsMonitor<DeliveryOptions>>();
             A.CallTo(() => mock.CurrentValue).Returns(options);
             return mock;
+        }
+        
+        public static IOptionsMonitor<DeliveryOptions> CreateMonitor(Guid projectId)
+        {
+            return CreateMonitor(new DeliveryOptions { ProjectId = projectId.ToString() });
         }
 
         public static IOptions<DeliveryOptions> Create(DeliveryOptions options)

--- a/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/coffee_beverages_explained.json
+++ b/Kentico.Kontent.Delivery.Tests/Fixtures/DeliveryClient/coffee_beverages_explained.json
@@ -40,8 +40,8 @@
             "size": 90895,
             "description": "Professional Espresso Machine",
             "url": "https://assets.kenticocloud.com:443/975bf280-fd91-488c-994c-2f04416e5ee3/e700596b-03b0-4cee-ac5c-9212762c027a/coffee-beverages-explained-1080px.jpg",
-            "width": 60,
-            "height": 60,
+            "width": 800,
+            "height": 600,
             "renditions": {
               "default": {
                 "rendition_id": "d44a2887-74cc-4ab0-8376-ae96f3f534e5",

--- a/Kentico.Kontent.Delivery.Tests/ModelProviderTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/ModelProviderTests.cs
@@ -19,6 +19,7 @@ namespace Kentico.Kontent.Delivery.Tests
         [Fact]
         public async Task RetrievingContentModelWithCircularDependencyDoesNotCycle()
         {
+            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(Guid.NewGuid());
             var typeProvider = A.Fake<ITypeProvider>();
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var propertyMapper = A.Fake<IPropertyMapper>();
@@ -28,7 +29,7 @@ namespace Kentico.Kontent.Delivery.Tests
             var processor = InlineContentItemsProcessorFactory
                 .WithResolver(ResolveItemWithSingleRte)
                 .Build();
-            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser());
+            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
 
             var item = JToken.FromObject(Rt1);
             var linkedItems = JToken.FromObject(LinkedItemsForItemWithTwoReferencedContentItems);
@@ -42,6 +43,7 @@ namespace Kentico.Kontent.Delivery.Tests
         [Fact]
         public async Task RetrievingNonExistentContentModelCreatesWarningInRichtext()
         {
+            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(Guid.NewGuid());
             var typeProvider = A.Fake<ITypeProvider>();
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var propertyMapper = A.Fake<IPropertyMapper>();
@@ -51,7 +53,7 @@ namespace Kentico.Kontent.Delivery.Tests
             var processor = InlineContentItemsProcessorFactory
                 .WithResolver(factory => factory.ResolveTo<UnknownContentItem>(unknownItem => $"Content type '{unknownItem.Type}' has no corresponding model."))
                 .Build();
-            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser());
+            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
 
             var item = JToken.FromObject(Rt5);
             var linkedItems = JToken.FromObject(LinkedItemWithNoModel);
@@ -71,6 +73,7 @@ namespace Kentico.Kontent.Delivery.Tests
         [Fact]
         public async Task RetrievingContentModelWithItemInlineReferencingItselfDoesNotCycle()
         {
+            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(Guid.NewGuid());
             var typeProvider = A.Fake<ITypeProvider>();
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var propertyMapper = A.Fake<IPropertyMapper>();
@@ -80,7 +83,7 @@ namespace Kentico.Kontent.Delivery.Tests
             var processor = InlineContentItemsProcessorFactory
                 .WithResolver(ResolveItemWithSingleRte)
                 .Build();
-            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser());
+            var retriever = new ModelProvider(contentLinkUrlResolver, processor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
 
             var item = JToken.FromObject(Rt3);
             var linkedItems = JToken.FromObject(LinkedItemsForItemReferencingItself);
@@ -98,12 +101,13 @@ namespace Kentico.Kontent.Delivery.Tests
             var item = JToken.FromObject(Rt4);
             var linkedItems = JToken.FromObject(LinkedItemsForItemWithTwoReferencedContentItems);
 
+            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(Guid.NewGuid());
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
             var inlineContentItemsProcessor = A.Fake<IInlineContentItemsProcessor>();
             var typeProvider = A.Fake<ITypeProvider>();
             var propertyMapper = A.Fake<IPropertyMapper>();
             A.CallTo(() => typeProvider.GetType("newType")).Returns(null);
-            var modelProvider = new ModelProvider(contentLinkUrlResolver, inlineContentItemsProcessor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser());
+            var modelProvider = new ModelProvider(contentLinkUrlResolver, inlineContentItemsProcessor, typeProvider, propertyMapper, new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
 
             Assert.Null(await modelProvider.GetContentItemModelAsync<object>(item, linkedItems));
         }

--- a/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/QueryParameters/ContentTypeExtractorTests.cs
@@ -25,7 +25,7 @@ namespace Kentico.Kontent.Delivery.Tests.QueryParameters
             A.CallTo(() => contentTypeProvider.GetCodename(typeof(TypeWithoutContentTypeCodename))).Returns(null);
 
             var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(new DeliveryOptions { ProjectId = FAKE_PROJECT_ID });
-            var modelProvider = new ModelProvider(null, null, contentTypeProvider, null, new DeliveryJsonSerializer(), new HtmlParser());
+            var modelProvider = new ModelProvider(null, null, contentTypeProvider, null, new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
             _client = new DeliveryClient(
                 deliveryOptions,
                 modelProvider,

--- a/Kentico.Kontent.Delivery.Tests/ValueConverterTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/ValueConverterTests.cs
@@ -51,9 +51,8 @@ namespace Kentico.Kontent.Delivery.Tests
         public async void GreeterPropertyValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
-            string url = $"{_baseUrl}/items/on_roasts";
-            mockHttp.When(url).
-               Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}on_roasts.json")));
+            mockHttp.When($"{_baseUrl}/items/on_roasts")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}on_roasts.json")));
             DeliveryClient client = InitializeDeliveryClient(mockHttp);
 
             var article = await client.GetItemAsync<Article>("on_roasts");
@@ -65,9 +64,8 @@ namespace Kentico.Kontent.Delivery.Tests
         public async void NodaTimePropertyValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
-            string url = $"{_baseUrl}/items/on_roasts";
-            mockHttp.When(url).
-               Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}on_roasts.json")));
+            mockHttp.When($"{_baseUrl}/items/on_roasts")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}on_roasts.json")));
             DeliveryClient client = InitializeDeliveryClient(mockHttp);
 
             var article = await client.GetItemAsync<Article>("on_roasts");
@@ -79,10 +77,9 @@ namespace Kentico.Kontent.Delivery.Tests
         public async void RichTextViaValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
-            string url = $"{_baseUrl}/items/coffee_beverages_explained";
-            mockHttp.When(url).
-               WithQueryString("depth=15").
-               Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}coffee_beverages_explained.json")));
+            mockHttp.When($"{_baseUrl}/items/coffee_beverages_explained")
+                .WithQueryString("depth=15")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}ContentLinkResolver{Path.DirectorySeparatorChar}coffee_beverages_explained.json")));
             DeliveryClient client = InitializeDeliveryClient(mockHttp);
 
             // Try to get recursive linked items on_roasts -> item -> on_roasts
@@ -94,17 +91,76 @@ namespace Kentico.Kontent.Delivery.Tests
             Assert.NotNull(hostedVideo);
             Assert.NotNull(tweet);
         }
+        
+        [Fact]
+        public async Task AssetElementValueConverter_NoPresetSpecifiedInConfig_AssetUrlIsUntouched()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp
+                .When($"{_baseUrl}/items/coffee_beverages_explained")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}coffee_beverages_explained.json")));
 
-        private DeliveryClient InitializeDeliveryClient(MockHttpMessageHandler mockHttp)
+            var client = InitializeDeliveryClient(mockHttp);
+
+            var response = await client.GetItemAsync<Article>("coffee_beverages_explained");
+            var teaserImage = response.Item.TeaserImage.FirstOrDefault();
+
+            var assetUrl = "https://assets.kenticocloud.com:443/975bf280-fd91-488c-994c-2f04416e5ee3/e700596b-03b0-4cee-ac5c-9212762c027a/coffee-beverages-explained-1080px.jpg";
+
+            Assert.Equal(assetUrl, teaserImage.Url);
+        }
+        
+        [Fact]
+        public async Task AssetElementValueConverter_DefaultPresetSpecifiedInConfig_AssetUrlContainsDefaultRenditionQuery()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp
+                .When($"{_baseUrl}/items/coffee_beverages_explained")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}coffee_beverages_explained.json")));
+
+            var defaultRenditionPreset = "default";
+
+            var client = InitializeDeliveryClient(mockHttp, new DeliveryOptions { ProjectId = _guid, DefaultRenditionPreset = defaultRenditionPreset});
+
+            var response = await client.GetItemAsync<Article>("coffee_beverages_explained");
+            var teaserImage = response.Item.TeaserImage.FirstOrDefault();
+
+            var assetUrl = "https://assets.kenticocloud.com:443/975bf280-fd91-488c-994c-2f04416e5ee3/e700596b-03b0-4cee-ac5c-9212762c027a/coffee-beverages-explained-1080px.jpg";
+            var defaultRenditionQuery = "w=200&h=150&fit=clip&rect=7,23,300,200";
+
+            Assert.Equal($"{assetUrl}?{defaultRenditionQuery}", teaserImage.Url);
+        }
+        
+        [Fact]
+        public async Task AssetElementValueConverter_MobilePresetSpecifiedInConfig_AssetUrlIsUntouchedAsThereIsNoMobileRenditionSpecified()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp
+                .When($"{_baseUrl}/items/coffee_beverages_explained")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}coffee_beverages_explained.json")));
+
+            var defaultRenditionPreset = "mobile";
+
+            var client = InitializeDeliveryClient(mockHttp, new DeliveryOptions { ProjectId = _guid, DefaultRenditionPreset = defaultRenditionPreset});
+            
+            var response = await client.GetItemAsync<Article>("coffee_beverages_explained");
+            var teaserImage = response.Item.TeaserImage.FirstOrDefault();
+
+            var assetUrl = "https://assets.kenticocloud.com:443/975bf280-fd91-488c-994c-2f04416e5ee3/e700596b-03b0-4cee-ac5c-9212762c027a/coffee-beverages-explained-1080px.jpg";
+
+            Assert.Equal(assetUrl, teaserImage.Url);
+        }
+
+        private DeliveryClient InitializeDeliveryClient(MockHttpMessageHandler mockHttp, DeliveryOptions options = null)
         {
             var deliveryHttpClient = new DeliveryHttpClient(mockHttp.ToHttpClient());
             var contentLinkUrlResolver = A.Fake<IContentLinkUrlResolver>();
-            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(new DeliveryOptions { ProjectId = _guid });
+            var deliveryOptions = DeliveryOptionsFactory.CreateMonitor(options ?? new DeliveryOptions { ProjectId = _guid });
             var retryPolicy = A.Fake<IRetryPolicy>();
             var retryPolicyProvider = A.Fake<IRetryPolicyProvider>();
             A.CallTo(() => retryPolicyProvider.GetRetryPolicy()).Returns(retryPolicy);
             A.CallTo(() => retryPolicy.ExecuteAsync(A<Func<Task<HttpResponseMessage>>>._)).ReturnsLazily(c => c.GetArgument<Func<Task<HttpResponseMessage>>>(0)());
-            var modelProvider = new ModelProvider(contentLinkUrlResolver, null, new CustomTypeProvider(), new PropertyMapper(), new DeliveryJsonSerializer(), new HtmlParser());
+            var modelProvider = new ModelProvider(contentLinkUrlResolver, null, new CustomTypeProvider(), new PropertyMapper(), new DeliveryJsonSerializer(), new HtmlParser(), deliveryOptions);
             var client = new DeliveryClient(deliveryOptions, modelProvider, retryPolicyProvider, null, deliveryHttpClient);
 
             return client;

--- a/Kentico.Kontent.Delivery/Configuration/DeliveryOptionsBuilder.cs
+++ b/Kentico.Kontent.Delivery/Configuration/DeliveryOptionsBuilder.cs
@@ -98,6 +98,13 @@ namespace Kentico.Kontent.Delivery.Configuration
             return this;
         }
 
+        IOptionalDeliveryConfiguration IOptionalDeliveryConfiguration.WithDefaultRenditionPreset(string presetCodename)
+        {
+            _deliveryOptions.DefaultRenditionPreset = presetCodename;
+            
+            return this;
+        }
+
         private void SetCustomEndpoint(string endpoint)
         {
             if (_deliveryOptions.UsePreviewApi)

--- a/Kentico.Kontent.Delivery/Configuration/IDeliveryOptionsBuilder.cs
+++ b/Kentico.Kontent.Delivery/Configuration/IDeliveryOptionsBuilder.cs
@@ -95,6 +95,15 @@ namespace Kentico.Kontent.Delivery.Configuration
         /// </remarks>
         /// <param name="customEndpoint">A custom endpoint URI.</param>
         IOptionalDeliveryConfiguration WithCustomEndpoint(Uri customEndpoint);
+
+        /// <summary>
+        /// Apply rendition of given preset to the asset URLs by default.
+        /// </summary>
+        /// <remarks> 
+        /// If not configured, asset URLs will always point to non-customized variant of the image.
+        /// </remarks>
+        /// <param name="presetCodename">Codename of the rendition preset to be applied automatically.</param>
+        IOptionalDeliveryConfiguration WithDefaultRenditionPreset(string presetCodename);
     }
 
     /// <summary>

--- a/Kentico.Kontent.Delivery/ContentItems/AssetElementValueConverter.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/AssetElementValueConverter.cs
@@ -9,11 +9,11 @@ using Microsoft.Extensions.Options;
 
 namespace Kentico.Kontent.Delivery.ContentItems
 {
-    internal class AssetValueConverter : IPropertyValueConverter<IEnumerable<IAsset>>
+    internal class AssetElementValueConverter : IPropertyValueConverter<IEnumerable<IAsset>>
     {
         public IOptionsMonitor<DeliveryOptions> Options { get; }
 
-        public AssetValueConverter(IOptionsMonitor<DeliveryOptions> options)
+        public AssetElementValueConverter(IOptionsMonitor<DeliveryOptions> options)
         {
             Options = options;
         }
@@ -40,13 +40,13 @@ namespace Kentico.Kontent.Delivery.ContentItems
                     Renditions = asset.Renditions,
                     Size = asset.Size,
                     Type = asset.Type,
-                    Url = ResolvedAssetUrl(asset),
+                    Url = ResolveAssetUrl(asset),
                 })
                 .Cast<IAsset>()
                 .ToList();
         }
 
-        private string ResolvedAssetUrl(IAsset asset)
+        private string ResolveAssetUrl(IAsset asset)
         {
             var renditionPresetToBeApplied = Options.CurrentValue.DefaultRenditionPreset;
             if (renditionPresetToBeApplied == null || asset.Renditions == null)

--- a/Kentico.Kontent.Delivery/ContentItems/AssetValueConverter.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/AssetValueConverter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Delivery.ContentItems.Elements;
+using Microsoft.Extensions.Options;
+
+namespace Kentico.Kontent.Delivery.ContentItems
+{
+    internal class AssetValueConverter : IPropertyValueConverter<IEnumerable<IAsset>>
+    {
+        public IOptionsMonitor<DeliveryOptions> Options { get; }
+
+        public AssetValueConverter(IOptionsMonitor<DeliveryOptions> options)
+        {
+            Options = options;
+        }
+
+        public async Task<object> GetPropertyValueAsync<TElement>(PropertyInfo property, TElement contentElement, ResolvingContext context) where TElement : IContentElementValue<IEnumerable<IAsset>>
+        {
+            if (!typeof(IEnumerable<IAsset>).IsAssignableFrom(property.PropertyType))
+            {
+                throw new InvalidOperationException($"Type of property {property.Name} must implement {nameof(IEnumerable<IAsset>)} in order to receive asset content.");
+            }
+
+            if (!(contentElement is AssetElementValue assetElementValue))
+            {
+                return null;
+            }
+
+            return assetElementValue.Value
+                .Select(asset => new Asset
+                {
+                    Description = asset.Description,
+                    Name = asset.Name,
+                    Height = asset.Height,
+                    Width = asset.Width,
+                    Renditions = asset.Renditions,
+                    Size = asset.Size,
+                    Type = asset.Type,
+                    Url = ResolvedAssetUrl(asset),
+                })
+                .Cast<IAsset>()
+                .ToList();
+        }
+
+        private string ResolvedAssetUrl(IAsset asset)
+        {
+            var renditionPresetToBeApplied = Options.CurrentValue.DefaultRenditionPreset;
+            if (renditionPresetToBeApplied == null || asset.Renditions == null)
+                return asset.Url;
+            
+            return asset.Renditions.TryGetValue(renditionPresetToBeApplied, out var renditionToBeApplied)
+                ? $"{asset.Url}?{renditionToBeApplied.Query}"
+                : asset.Url;
+        }
+    }
+}

--- a/Kentico.Kontent.Delivery/ContentItems/Elements/AssetElementValue.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/Elements/AssetElementValue.cs
@@ -1,0 +1,9 @@
+﻿using Kentico.Kontent.Delivery.Abstractions;
+using System.Collections.Generic;
+
+namespace Kentico.Kontent.Delivery.ContentItems.Elements
+{
+    internal class AssetElementValue : ContentElementValue<IEnumerable<IAsset>>, IAssetElementValue
+    {
+    }
+}

--- a/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/ModelProvider.cs
@@ -381,7 +381,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
 
             if (property.PropertyType == typeof(IEnumerable<IAsset>))
             {
-                return new AssetValueConverter(DeliveryOptions);
+                return new AssetElementValueConverter(DeliveryOptions);
             }
             
             return null;


### PR DESCRIPTION
### Motivation
https://github.com/Kentico/kontent-delivery-sdk-net/issues/318

Users are having a hard time adopting the new asset renditions feature as the SDKs always return the original asset URL by default. We'd like to add an option to configure the default preset codename to be applied when such rendition exists in the Delivery API response.

Underlying Jira issue: https://kentico.atlassian.net/browse/KCL-8387

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

I wrote some unit tests...
