### PR TITLE
Allow setting the continuation token when retrieving a batch from feed

### DIFF
--- a/Kentico.Kontent.Delivery.Abstractions/ContentItems/IDeliveryItemsFeed.cs
+++ b/Kentico.Kontent.Delivery.Abstractions/ContentItems/IDeliveryItemsFeed.cs
@@ -16,7 +16,8 @@ namespace Kentico.Kontent.Delivery.Abstractions
         /// <summary>
         /// Retrieves the next feed batch if available.
         /// </summary>
+        /// <param name="continuationToken">Optional explicit continuation token that allows you to get the next batch from a specific point in the feed.</param>
         /// <returns>Instance of <see cref="IDeliveryItemsFeedResponse{T}"/> class that contains a list of strongly typed content items.</returns>
-        Task<IDeliveryItemsFeedResponse<T>> FetchNextBatchAsync();
+        Task<IDeliveryItemsFeedResponse<T>> FetchNextBatchAsync(string continuationToken = null);
     }
 }

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -284,7 +284,7 @@ namespace Kentico.Kontent.Delivery.Tests
         }
 
         [Fact]
-        public async Task GetItemsFeed_SingleBatch_FetchNextBatchAsync_ContinuationToken()
+        public async Task GetItemsFeed_SingleBatchWithContinuationToken_FetchNextBatchAsync()
         {
             // Single batch with specific continuation token.
             _mockHttp

--- a/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kentico.Kontent.Delivery.Tests/DeliveryClientTests.cs
@@ -284,6 +284,32 @@ namespace Kentico.Kontent.Delivery.Tests
         }
 
         [Fact]
+        public async Task GetItemsFeed_SingleBatch_FetchNextBatchAsync_ContinuationToken()
+        {
+            // Single batch with specific continuation token.
+            _mockHttp
+                .When($"{_baseUrl}/items-feed")
+                .WithQueryString("system.type=article")
+                .WithHeaders("X-Continuation", "token")
+                .Respond("application/json", await File.ReadAllTextAsync(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}DeliveryClient{Path.DirectorySeparatorChar}articles_feed.json")));
+
+            var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
+
+            var feed = client.GetItemsFeed<Article>();
+            var items = new List<Article>();
+            var timesCalled = 0;
+            while (feed.HasMoreResults)
+            {
+                timesCalled++;
+                var response = await feed.FetchNextBatchAsync("token");
+                items.AddRange(response.Items);
+            }
+
+            Assert.Equal(6, items.Count);
+            Assert.Equal(1, timesCalled);
+        }
+
+        [Fact]
         public async Task GetItemsFeed_MultipleBatches_FetchNextBatchAsync()
         {
             // Second batch

--- a/Kentico.Kontent.Delivery/ContentItems/DeliveryItemsFeed.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/DeliveryItemsFeed.cs
@@ -32,15 +32,16 @@ namespace Kentico.Kontent.Delivery.ContentItems
         /// <summary>
         /// Retrieves the next feed batch if available.
         /// </summary>
+        /// <param name="continuationToken">Optional explicit continuation token that allows you to get the next batch from a specific point in the feed.</param>
         /// <returns>Instance of <see cref="DeliveryItemsFeedResponse{T}"/> class that contains a list of strongly typed content items.</returns>
-        public async Task<IDeliveryItemsFeedResponse<T>> FetchNextBatchAsync()
+        public async Task<IDeliveryItemsFeedResponse<T>> FetchNextBatchAsync(string continuationToken = null)
         {
             if (!HasMoreResults)
             {
                 throw new InvalidOperationException("The feed has already been enumerated and there are no more results.");
             }
 
-            var response = await _getFeedResponseAsync(_continuationToken);
+            var response = await _getFeedResponseAsync(continuationToken ?? _continuationToken);
             _continuationToken = response.ApiResponse.ContinuationToken;
             HasMoreResults = !string.IsNullOrEmpty(response.ApiResponse.ContinuationToken);
 


### PR DESCRIPTION
Allow setting the continuation token when retrieving a batch from a feed.

### Motivation

This is a solution for #316 

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
