### PR TITLE
 DeliveryEndpointUrlBuilder(DeliveryOptions deliveryOptions) marked obsolete + potential null fix #329 

### DIFF
--- a/Kentico.Kontent.Delivery/DeliveryClient.cs
+++ b/Kentico.Kontent.Delivery/DeliveryClient.cs
@@ -146,7 +146,7 @@ namespace Kentico.Kontent.Delivery
 
             var endpointUrl = UrlBuilder.GetTypeUrl(codename);
             var response = await GetDeliveryResponseAsync(endpointUrl);
-            var type = (await response.GetJsonContentAsync())?.ToObject<ContentType>(Serializer);
+            var type = (await response.GetJsonContentAsync()).ToObject<ContentType>(Serializer);
 
             return new DeliveryTypeResponse(response, type);
         }

--- a/Kentico.Kontent.Urls.Tests/DeliveryEndpointUrlBuilderTests.cs
+++ b/Kentico.Kontent.Urls.Tests/DeliveryEndpointUrlBuilderTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Kentico.Kontent.Delivery.Abstractions;
+using Kentico.Kontent.Urls.Delivery;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Kentico.Kontent.Urls.Tests;
+
+public class DeliveryEndpointUrlBuilderTests
+{
+    //as this is only place where mock would be used, just fake implementation class is created
+    //if more mocking is to be used, please use mocking library like NSubstitute instead
+    private class FakeOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; }
+
+        public FakeOptionsMonitor(T options)
+        {
+            CurrentValue = options;
+        }
+        
+        public T Get(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable OnChange(Action<T, string> listener)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [Fact]
+    public void GetLanguagesUrl_ConstructedWithDeliveryOptions_GetsLanguagesUrl()
+    {
+        var options = new DeliveryOptions() { ProjectId = Guid.NewGuid().ToString() };
+
+        var deliveryEndpointUrlBuilder = new DeliveryEndpointUrlBuilder(options);
+
+        var actualLanguagesUrl = deliveryEndpointUrlBuilder.GetLanguagesUrl(new IQueryParameter[] { });
+
+        var expectedLanguagesUrl = $"https://deliver.kontent.ai:443/{options.ProjectId}/languages";
+        Assert.Equal(expectedLanguagesUrl, actualLanguagesUrl);
+    }
+    
+    [Fact]
+    public void GetLanguagesUrl_ConstructedWithDeliveryOptionsMonitor_GetsLanguagesUrl()
+    {
+        var options = new DeliveryOptions() { ProjectId = Guid.NewGuid().ToString() };
+        var optionsMonitor = new FakeOptionsMonitor<DeliveryOptions>(options);
+
+        var deliveryEndpointUrlBuilder = new DeliveryEndpointUrlBuilder(optionsMonitor);
+
+        var actualLanguagesUrl = deliveryEndpointUrlBuilder.GetLanguagesUrl(new IQueryParameter[] { });
+
+        var expectedLanguagesUrl = $"https://deliver.kontent.ai:443/{options.ProjectId}/languages";
+        Assert.Equal(expectedLanguagesUrl, actualLanguagesUrl);
+    }
+}

--- a/Kentico.Kontent.Urls/Delivery/DeliveryEndpointUrlBuilder.cs
+++ b/Kentico.Kontent.Urls/Delivery/DeliveryEndpointUrlBuilder.cs
@@ -30,7 +30,7 @@ namespace Kentico.Kontent.Urls.Delivery
         {
             get
             {
-                return _deliveryOptionsMonitor.CurrentValue ?? deliveryOptions;
+                return _deliveryOptionsMonitor?.CurrentValue ?? deliveryOptions;
             }
             set
             {
@@ -51,6 +51,7 @@ namespace Kentico.Kontent.Urls.Delivery
         /// Initializes the URL builder using <see cref="IOptionsMonitor{TOptions}"/>. Ideal for simple scenarios where hot reloading of configuration is not required.
         /// </summary>
         /// <param name="deliveryOptions">The configuration object.</param>
+        [Obsolete]
         public DeliveryEndpointUrlBuilder(DeliveryOptions deliveryOptions)
         {
             CurrentDeliveryOptions = deliveryOptions;


### PR DESCRIPTION
### Motivation

Fixes #327

`DeliveryEndpointUrlBuilder(DeliveryOptions deliveryOptions)` marked as obsolete and fixed potential null situation when this constructor would be used and property CurrentDeliveryOptions would be use read.