### PR TITLE
Async keyword replaced by Task.FromResult creation of result object.

### DIFF
--- a/Kentico.Kontent.Delivery/ContentItems/AssetElementValueConverter.cs
+++ b/Kentico.Kontent.Delivery/ContentItems/AssetElementValueConverter.cs
@@ -18,7 +18,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
             Options = options;
         }
 
-        public async Task<object> GetPropertyValueAsync<TElement>(PropertyInfo property, TElement contentElement, ResolvingContext context) where TElement : IContentElementValue<IEnumerable<IAsset>>
+        public Task<object> GetPropertyValueAsync<TElement>(PropertyInfo property, TElement contentElement, ResolvingContext context) where TElement : IContentElementValue<IEnumerable<IAsset>>
         {
             if (!typeof(IEnumerable<IAsset>).IsAssignableFrom(property.PropertyType))
             {
@@ -30,7 +30,7 @@ namespace Kentico.Kontent.Delivery.ContentItems
                 return null;
             }
 
-            return assetElementValue.Value
+            var assets = assetElementValue.Value
                 .Select(asset => new Asset
                 {
                     Description = asset.Description,
@@ -44,6 +44,8 @@ namespace Kentico.Kontent.Delivery.ContentItems
                 })
                 .Cast<IAsset>()
                 .ToList();
+
+            return Task.FromResult((object)assets);
         }
 
         private string ResolveAssetUrl(IAsset asset)


### PR DESCRIPTION
### Motivation

Fixes #330.

Solves issue from warning, that async code will be executed synchrnonoustly. As this code is in fact synchronous `async` keyword usage was replaced by `Task.FromResult` creation of result object (list of assets).

No new unit test was introduced as this should be covered by existing unit tests.

