### PR TITLE
Upgraded Newtonsoft Json dependency to fix severe vulnerability issue

### DIFF
--- a/Kentico.Kontent.Delivery.Caching/Kentico.Kontent.Delivery.Caching.csproj
+++ b/Kentico.Kontent.Delivery.Caching/Kentico.Kontent.Delivery.Caching.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Scrutor" Version="3.2.2" />
   </ItemGroup>

--- a/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
+++ b/Kentico.Kontent.Delivery.Rx/Kentico.Kontent.Delivery.Rx.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/Kentico.Kontent.Delivery/Kentico.Kontent.Delivery.csproj
+++ b/Kentico.Kontent.Delivery/Kentico.Kontent.Delivery.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Scrutor" Version="3.2.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />


### PR DESCRIPTION
### Motivation

Updated Newtonsoft.Json dependency to recommended version to fix severe vulnerability issue. Fixes  #`338`.
